### PR TITLE
feat: auth kernels route on go and ts (nullable and seq bridges)

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -222,10 +222,12 @@ jobs:
             dialect: postgres
             migrate_url: postgres://app:app@localhost:5432/app?sslmode=disable
             db_url: postgres://app:app@localhost:5432/app?sslmode=disable
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
           - fixture: auth_service
             dialect: sqlite
             migrate_url: sqlite://app.db
             db_url: file:app.db?cache=shared&_pragma=foreign_keys(1)
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
     services:
       postgres:
         image: postgres:17-alpine

--- a/.github/workflows/ts-build.yml
+++ b/.github/workflows/ts-build.yml
@@ -218,9 +218,11 @@ jobs:
           - fixture: auth_service
             dialect: postgres
             db_url: postgresql://app:app@localhost:5432/app
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
           - fixture: auth_service
             dialect: sqlite
             db_url: file:./app.db
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
     services:
       postgres:
         image: postgres:17-alpine

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+
 	"github.com/uptrace/bun"
 
 	"github.com/generated/url-shortener/internal/config"

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/url_mapping.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+
 	"github.com/uptrace/bun"
 
 	"github.com/generated/url-shortener/internal/config"

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"errors"
+
 	"github.com/uptrace/bun"
 
 	"github.com/generated/url-shortener/internal/config"

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/dafnykernel/adapter.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/dafnykernel/adapter.go.hbs
@@ -1,6 +1,10 @@
 package kernel
 
-import _dafny "{{module}}/internal/dafnykernel/dafny"
+import (
+	"time"
+
+	_dafny "{{module}}/internal/dafnykernel/dafny"
+)
 
 func MakeState() *ServiceState {
 	return New_ServiceState_()
@@ -20,4 +24,64 @@ func IntToDafny(n int64) _dafny.Int {
 
 func IntFromDafny(n _dafny.Int) int64 {
 	return n.Int64()
+}
+
+func OptStringToDafny(p *string) Option {
+	if p == nil {
+		return Companion_Option_.Create_None_()
+	}
+	return Companion_Option_.Create_Some_(StringToDafny(*p))
+}
+
+func OptStringFromDafny(o Option) *string {
+	if !o.Is_Some() {
+		return nil
+	}
+	v := StringFromDafny(o.Dtor_value().(_dafny.Sequence))
+	return &v
+}
+
+func OptIntToDafny(p *int64) Option {
+	if p == nil {
+		return Companion_Option_.Create_None_()
+	}
+	return Companion_Option_.Create_Some_(IntToDafny(*p))
+}
+
+func OptIntFromDafny(o Option) *int64 {
+	if !o.Is_Some() {
+		return nil
+	}
+	v := IntFromDafny(o.Dtor_value().(_dafny.Int))
+	return &v
+}
+
+func OptTimeToDafny(p *time.Time) Option {
+	if p == nil {
+		return Companion_Option_.Create_None_()
+	}
+	return Companion_Option_.Create_Some_(IntToDafny(p.Unix()))
+}
+
+func OptTimeFromDafny(o Option) *time.Time {
+	if !o.Is_Some() {
+		return nil
+	}
+	v := time.Unix(IntFromDafny(o.Dtor_value().(_dafny.Int)), 0).UTC()
+	return &v
+}
+
+func OptBoolToDafny(p *bool) Option {
+	if p == nil {
+		return Companion_Option_.Create_None_()
+	}
+	return Companion_Option_.Create_Some_(*p)
+}
+
+func OptBoolFromDafny(o Option) *bool {
+	if !o.Is_Some() {
+		return nil
+	}
+	v := o.Dtor_value().(bool)
+	return &v
 }

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
@@ -28,7 +28,9 @@ func (h *{{../entity.entity.modelClassName}}Handler) {{handlerName}}(w http.Resp
 		writeError(w, http.StatusUnprocessableEntity, err.Error())
 		return
 	}
-{{/if}}{{/if}}{{#if routeThroughKernel}}	result, err := h.svc.{{serviceMethod}}(r.Context(){{#if kernelHandlerArgs}}, {{kernelHandlerArgs}}{{/if}})
+{{/if}}{{/if}}{{#if routeThroughKernel}}{{#if kernelNoResult}}	err := h.svc.{{serviceMethod}}(r.Context(){{#if kernelHandlerArgs}}, {{kernelHandlerArgs}}{{/if}})
+{{else}}	result, err := h.svc.{{serviceMethod}}(r.Context(){{#if kernelHandlerArgs}}, {{kernelHandlerArgs}}{{/if}})
+{{/if}}
 	if err != nil {
 		if errors.Is(err, services.ErrKernelPrecondition) {
 			writeError(w, {{kernelGuardStatus}}, "{{kernelGuardDetail}}")
@@ -37,9 +39,10 @@ func (h *{{../entity.entity.modelClassName}}Handler) {{handlerName}}(w http.Resp
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-{{#if kernelRedirect}}	http.Redirect(w, r, result, {{successStatus}})
+{{#if kernelNoResult}}	w.WriteHeader({{successStatus}})
+{{else}}{{#if kernelRedirect}}	http.Redirect(w, r, result, {{successStatus}})
 {{else}}	writeJSON(w, {{successStatus}}, result)
-{{/if}}{{else}}{{#if (eq routeKind "create")}}	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
+{{/if}}{{/if}}{{else}}{{#if (eq routeKind "create")}}	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/services/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/services/entity.go.hbs
@@ -1,11 +1,7 @@
 package services
 
 import (
-{{#if entity.hasOperations}}	"context"
-{{/if}}{{#if entity.usesSqlNoRows}}	"database/sql"
-{{/if}}{{#if entity.usesErrors}}	"errors"
-{{/if}}
-	"github.com/uptrace/bun"
+{{{entity.serviceStdlibImports}}}	"github.com/uptrace/bun"
 
 	"{{module}}/internal/config"
 {{#if entity.usesKernel}}	dafnykernel "{{module}}/internal/dafnykernel"

--- a/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
@@ -32,7 +32,8 @@ export const stringToDafny = (s: string): unknown =>
 export const stringFromDafny = (s: unknown): string =>
   (s as DafnySeq).toVerbatimString(false);
 
-export const intToDafny = (n: number): unknown => new BigNumber(n);
+export const intToDafny = (n: number | bigint): unknown =>
+  new BigNumber(typeof n === 'bigint' ? n.toString() : n);
 
 export const intFromDafny = (n: unknown): number => (n as DafnyInt).toNumber();
 

--- a/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
@@ -37,6 +37,11 @@ export const intToDafny = (n: number | bigint): unknown =>
 
 export const intFromDafny = (n: unknown): number => (n as DafnyInt).toNumber();
 
+// Lossless decimal rendering of a Dafny integer: toNumber() rounds past
+// 2^53, so identity keys stringify straight from the BigNumber.
+export const intKeyFromDafny = (n: unknown): string =>
+  (n as DafnyInt & { toFixed(dp: number): string }).toFixed(0);
+
 interface DafnyOption {
   is_Some: boolean;
   value: unknown;

--- a/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
@@ -57,8 +57,19 @@ export const valueOrNull = (opt: unknown, conv: (v: unknown) => unknown): unknow
   return o.is_Some ? conv(o.value) : null;
 };
 
-export const dafnySeqOf = (values: unknown[]): unknown =>
-  (kernel._dafny.Seq as { of(...xs: unknown[]): unknown }).of(...values);
+export const dafnySeqOf = (values: unknown[]): unknown => {
+  // Chunked concatenation: spreading every element into one variadic call
+  // hits engine argument limits on large hydrations.
+  const S = kernel._dafny.Seq as {
+    of(...xs: unknown[]): unknown;
+    Concat(a: unknown, b: unknown): unknown;
+  };
+  let out = S.of();
+  for (let i = 0; i < values.length; i += 512) {
+    out = S.Concat(out, S.of(...values.slice(i, i + 512)));
+  }
+  return out;
+};
 
 // Fresh secrets come from the CSPRNG, never from the verified (hence
 // deterministic) kernel; the compiled Requires twin validates each sample

--- a/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
@@ -36,6 +36,29 @@ export const intToDafny = (n: number): unknown => new BigNumber(n);
 
 export const intFromDafny = (n: unknown): number => (n as DafnyInt).toNumber();
 
+interface DafnyOption {
+  is_Some: boolean;
+  value: unknown;
+}
+
+const optionCompanion = dafnyModule['Option'] as unknown as {
+  create_Some(value: unknown): unknown;
+  create_None(): unknown;
+};
+
+export const someOrNone = (value: unknown, conv: (v: unknown) => unknown): unknown =>
+  value === null || value === undefined
+    ? optionCompanion.create_None()
+    : optionCompanion.create_Some(conv(value));
+
+export const valueOrNull = (opt: unknown, conv: (v: unknown) => unknown): unknown => {
+  const o = opt as DafnyOption;
+  return o.is_Some ? conv(o.value) : null;
+};
+
+export const dafnySeqOf = (values: unknown[]): unknown =>
+  (kernel._dafny.Seq as { of(...xs: unknown[]): unknown }).of(...values);
+
 // Fresh secrets come from the CSPRNG, never from the verified (hence
 // deterministic) kernel; the compiled Requires twin validates each sample
 // against live state before the kernel accepts it.

--- a/modules/codegen/src/main/resources/templates/ts/express/src/routes/entity.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/routes/entity.ts.hbs
@@ -44,11 +44,16 @@ export const register{{entity.entity.modelClassName}}Routes = (app: Express): vo
 {{#if hasRequestBody}}
       const body = req.body as service.{{requestBodyType}};
 {{/if}}
+{{#if kernelNoResult}}
+      await service.{{handlerName}}({{kernelRouteCallArgs}});
+      res.status({{successStatus}}).end();
+{{else}}
       const result = await service.{{handlerName}}({{kernelRouteCallArgs}});
 {{#if (eq routeKind "redirect")}}
       res.redirect({{successStatus}}, result);
 {{else}}
       res.status({{successStatus}}).json(result);
+{{/if}}
 {{/if}}
     }),
   );

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -5,6 +5,7 @@ import specrest.codegen.Compose
 import specrest.codegen.DafnyKernel
 import specrest.codegen.EmitOptions
 import specrest.codegen.EmitShared
+import specrest.codegen.SensitiveFields
 import specrest.codegen.EmittedFile
 import specrest.codegen.EnvExample
 import specrest.codegen.ExtensionStub
@@ -83,6 +84,7 @@ final private case class GoOperation(
     kernelGuardStatus: Int,
     kernelGuardDetail: String,
     kernelRedirect: Boolean,
+    kernelNoResult: Boolean,
     kernelHandlerArgs: String,
     lookupColumn: String,
     createAssigns: List[String],
@@ -110,6 +112,8 @@ final private case class GoEntityCtx(
     usesPathParams: Boolean,
     usesNotFound: Boolean,
     usesErrors: Boolean,
+    servicesNeedTime: Boolean,
+    serviceStdlibImports: String,
     usesSqlNoRows: Boolean,
     usesKernel: Boolean,
     usesModels: Boolean,
@@ -185,7 +189,7 @@ object EmitGo:
     val entities = profiled.entities.map: entity =>
       val entityOps = profiled.operations
         .filter(_.targetEntity.contains(entity.entityName))
-        .map(op => enrichOperation(op, entity, typeLookup, kernelCtx))
+        .map(op => enrichOperation(op, entity, profiled.entities, typeLookup, kernelCtx))
         .sortWith((a, b) => EmitShared.byPathSpecificity(a.path, b.path))
       buildEntityCtx(module, profiled, entity, entityOps)
 
@@ -642,6 +646,16 @@ object EmitGo:
       usesPathParams = usesPathParams,
       usesNotFound = usesNotFound,
       usesErrors = usesErrors,
+      servicesNeedTime = operations.exists(_.kernelServiceMethod.contains("time.Unix(")),
+      serviceStdlibImports = {
+        val lines = List(
+          Option.when(operations.nonEmpty)("\"context\""),
+          Option.when(usesSqlNoRows)("\"database/sql\""),
+          Option.when(usesErrors)("\"errors\""),
+          Option.when(operations.exists(_.kernelServiceMethod.contains("time.Unix(")))("\"time\"")
+        ).flatten
+        if lines.isEmpty then "" else lines.map("\t" + _).mkString("", "\n", "\n\n")
+      },
       usesSqlNoRows = usesSqlNoRows,
       usesKernel = usesKernel,
       usesModels = usesModels,
@@ -738,6 +752,7 @@ object EmitGo:
   private def enrichOperation(
       op: ProfiledOperation,
       entity: ProfiledEntity,
+      allEntities: List[ProfiledEntity],
       typeLookup: Map[String, String],
       kernelCtx: GoKernelCtx
   ): GoOperation =
@@ -846,12 +861,14 @@ object EmitGo:
       goKernelServiceMethod(
         op,
         entity,
+        allEntities,
         serviceMethodName,
         hasRequestBody,
         requestBodyType,
         typeLookup,
         kernelCtx
       )
+    val kernelNoResult = kernelMethod.exists(_._2)
     val kernelHandlerArgs =
       (endpoint.pathParams.map(p => toCamelCase(p.name)) ++
         (if hasRequestBody then List("body") else Nil)).mkString(", ")
@@ -879,10 +896,11 @@ object EmitGo:
       redirectField = redirectField,
       dafnyMethod = op.dafnyMethod,
       routeThroughKernel = kernelMethod.isDefined,
-      kernelServiceMethod = kernelMethod.getOrElse(""),
+      kernelServiceMethod = kernelMethod.map(_._1).getOrElse(""),
       kernelGuardStatus = kernelGuardStatus,
       kernelGuardDetail = if kernelGuardStatus == 404 then "not found" else "precondition failed",
       kernelRedirect = isRedirectKind,
+      kernelNoResult = kernelNoResult,
       kernelHandlerArgs = kernelHandlerArgs,
       lookupColumn = lookupCol,
       createAssigns = createAssigns,
@@ -908,10 +926,14 @@ object EmitGo:
     )
 
   private def goStateModel(fields: List[ScalarStateFieldView]): String =
-    val cols = fields
-      .map: f =>
-        val goField = Naming.toPascalCase(f.columnName, Naming.PascalStrategy.Go)
-        s"""\t$goField int64 `bun:"${f.columnName}" json:"${f.specName}"`"""
+    // gofmt aligns struct field columns, so the emitted names pad to the
+    // widest one (ID included) or a multi-scalar spec fails the fmt gate.
+    val names = "ID" :: fields.map(f => Naming.toPascalCase(f.columnName, Naming.PascalStrategy.Go))
+    val width = names.map(_.length).max
+    val cols = names
+      .zip(("id,pk" -> "id") :: fields.map(f => f.columnName -> f.specName))
+      .map: (goField, tags) =>
+        s"""\t${goField.padTo(width, ' ')} int64 `bun:"${tags._1}" json:"${tags._2}"`"""
       .mkString("\n")
     s"""|package models
         |
@@ -920,7 +942,6 @@ object EmitGo:
         |type ServiceState struct {
         |\tbun.BaseModel `bun:"table:${ScalarOps.TableName}"`
         |
-        |\tID int64 `bun:"id,pk" json:"id"`
         |$cols
         |}
         |""".stripMargin
@@ -1081,12 +1102,13 @@ func sampleCandidate(length int, charset string) (string, error) {
   private def goKernelServiceMethod(
       op: ProfiledOperation,
       entity: ProfiledEntity,
+      allEntities: List[ProfiledEntity],
       serviceMethod: String,
       hasRequestBody: Boolean,
       requestBodyType: String,
       typeLookup: Map[String, String],
       kernelCtx: GoKernelCtx
-  ): Option[String] =
+  ): Option[(String, Boolean)] =
     val endpoint = op.endpoint
     op.dafnyMethod
       .filter(_ => endpoint.queryParams.isEmpty && kernelCtx.stateReady)
@@ -1102,8 +1124,30 @@ func sampleCandidate(length int, charset string) (string, error) {
           goKernelScalarConv.get(goType).map: (toDafny, _) =>
             if toDafny.isEmpty then access else s"$toDafny($access)"
         val outputs = op.responseFields
+        val specOutputs = svcOperations(kernelCtx.ir)
+          .find(o => operName(o) == op.operationName)
+          .map(operOutputs)
+          .getOrElse(Nil)
+        // Mirrors the python marshalling: no outputs is a plain effect call,
+        // a single entity output projects the entity's read shape flat, and
+        // scalar outputs unpack positionally.
+        val entityOutput = specOutputs match
+          case single :: Nil =>
+            prmType(single) match
+              case NamedTypeF(n, _) => allEntities.find(_.entityName == n)
+              case _                => None
+          case _ => None
+        val entityOutputFields = entityOutput
+          .map(_.fields.filterNot(f => SensitiveFields.isSensitive(f.columnName)))
+          .getOrElse(Nil)
+        val goEntityTypes = Set("string", "int64", "bool", "time.Time")
         val outputsOk =
-          outputs.nonEmpty && outputs.forall(f => goKernelScalarConv.contains(f.domainType))
+          if specOutputs.isEmpty then true
+          else if entityOutput.isDefined then
+            entityOutputFields.nonEmpty && entityOutputFields.forall(f =>
+              goEntityTypes.contains(f.domainType.stripPrefix("*"))
+            )
+          else outputs.nonEmpty && outputs.forall(f => goKernelScalarConv.contains(f.domainType))
         Option.when(convertedArgs.forall(_.isDefined) && outputsOk):
           val candidates = op.dafnyCandidates.map: c =>
             (toCamelCase(c.param), c.sampleLength, goCandidateCharsetConst(c.param))
@@ -1125,31 +1169,46 @@ func sampleCandidate(length int, charset string) (string, error) {
             case "int64"  => "0"
             case "bool"   => "false"
             case _        => "nil"
+          val noResult = specOutputs.isEmpty
           val (returnType, zero, resultAssign) =
-            outputs match
-              case single :: Nil =>
-                val v = "out" + toPascalCase(single.fieldName)
-                (
-                  s"(${single.domainType}, error)",
-                  zeroOf(single.domainType),
-                  List(
-                    s"\t\t$v := $call",
-                    s"\t\tresult = ${fromDafny(single, v)}"
+            if noResult then ("error", "", List(s"\t\t$call"))
+            else if entityOutput.isDefined then
+              val keyTokens = entityOutputFields.map(f => s"\"${f.fieldName}\":")
+              val keyWidth  = keyTokens.map(_.length).max
+              val entries = entityOutputFields.zip(keyTokens).map: (f, key) =>
+                s"\t\t\t${key.padTo(keyWidth, ' ')} ${StateBridgeGo.fromDafnyExpr(f, "out")},"
+              (
+                "(map[string]any, error)",
+                "nil",
+                (s"\t\tout := $call" :: "\t\tresult = map[string]any{" :: entries) :::
+                  List("\t\t}")
+              )
+            else
+              outputs match
+                case single :: Nil =>
+                  val v = "out" + toPascalCase(single.fieldName)
+                  (
+                    s"(${single.domainType}, error)",
+                    zeroOf(single.domainType),
+                    List(
+                      s"\t\t$v := $call",
+                      s"\t\tresult = ${fromDafny(single, v)}"
+                    )
                   )
-                )
-              case many =>
-                val vars      = many.map(f => "out" + toPascalCase(f.fieldName))
-                val keyTokens = many.map(f => s"\"${f.columnName}\":")
-                val keyWidth  = keyTokens.map(_.length).max
-                val entries = many.zip(vars).zip(keyTokens).map: (fv, key) =>
-                  s"\t\t\t${key.padTo(keyWidth, ' ')} ${fromDafny(fv._1, fv._2)},"
-                (
-                  "(map[string]any, error)",
-                  "nil",
-                  (s"\t\t${vars.mkString(", ")} := $call" :: "\t\tresult = map[string]any{" :: entries) :::
-                    List("\t\t}")
-                )
+                case many =>
+                  val vars      = many.map(f => "out" + toPascalCase(f.fieldName))
+                  val keyTokens = many.map(f => s"\"${f.columnName}\":")
+                  val keyWidth  = keyTokens.map(_.length).max
+                  val entries = many.zip(vars).zip(keyTokens).map: (fv, key) =>
+                    s"\t\t\t${key.padTo(keyWidth, ' ')} ${fromDafny(fv._1, fv._2)},"
+                  (
+                    "(map[string]any, error)",
+                    "nil",
+                    (s"\t\t${vars.mkString(", ")} := $call" :: "\t\tresult = map[string]any{" :: entries) :::
+                      List("\t\t}")
+                  )
           val resultDecl = returnType match
+            case "error"                   => ""
             case "(map[string]any, error)" => "\tvar result map[string]any"
             case other                     => s"\tvar result ${outputs.head.domainType}"
           val invCheck =
@@ -1172,13 +1231,14 @@ func sampleCandidate(length int, charset string) (string, error) {
               // failure, not sampling bad luck.
               candidates.map((v, _, _) => s"\t\tvar $v string") :::
                 List("\t\tokCand := false", "\t\tfor attempt := 0; attempt < 8; attempt++ {") :::
-                candidates.flatMap: (v, len, const) =>
+                candidates.zipWithIndex.flatMap: (cand, i) =>
+                  val (v, len, const) = cand
                   List(
-                    s"\t\t\tsampled, err := sampleCandidate($len, $const)",
-                    "\t\t\tif err != nil {",
-                    "\t\t\t\treturn err",
+                    s"\t\t\tsampled$i, errSample$i := sampleCandidate($len, $const)",
+                    s"\t\t\tif errSample$i != nil {",
+                    s"\t\t\t\treturn errSample$i",
                     "\t\t\t}",
-                    s"\t\t\t$v = sampled"
+                    s"\t\t\t$v = sampled$i"
                   )
                 :::
                 List(
@@ -1193,6 +1253,8 @@ func sampleCandidate(length int, charset string) (string, error) {
                 )
           val header =
             s"func (s *${entity.modelClassName}Service) $serviceMethod(ctx context.Context$sig) $returnType {"
+          val errReturn = if noResult then "\t\treturn err" else s"\t\treturn $zero, err"
+          val okReturn  = if noResult then "\treturn nil" else "\treturn result, nil"
           val body =
             if kernelCtx.hasState then
               (header :: resultDecl ::
@@ -1206,9 +1268,9 @@ func sampleCandidate(length int, charset string) (string, error) {
                     "\t\t}",
                     "\t\treturn nil",
                     "\t}); err != nil {",
-                    s"\t\treturn $zero, err",
+                    errReturn,
                     "\t}",
-                    "\treturn result, nil",
+                    okReturn,
                     "}"
                   ))): List[String]
             else
@@ -1220,12 +1282,12 @@ func sampleCandidate(length int, charset string) (string, error) {
                     "\t\treturn nil",
                     "\t}()",
                     "\tif err != nil {",
-                    s"\t\treturn $zero, err",
+                    errReturn,
                     "\t}",
-                    "\treturn result, nil",
+                    okReturn,
                     "}"
                   ))): List[String]
-          body.mkString("\n")
+          (body.filter(_.nonEmpty).mkString("\n"), noResult)
 
   private def toCamelCase(name: String): String =
     Naming.toCamelCase(name, Naming.CamelStrategy.Plain)

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -1173,7 +1173,8 @@ func sampleCandidate(length int, charset string) (string, error) {
           val (returnType, zero, resultAssign) =
             if noResult then ("error", "", List(s"\t\t$call"))
             else if entityOutput.isDefined then
-              val keyTokens = entityOutputFields.map(f => s"\"${f.fieldName}\":")
+              // Keys match the entity read shape's json tags (column names).
+              val keyTokens = entityOutputFields.map(f => s"\"${f.columnName}\":")
               val keyWidth  = keyTokens.map(_.length).max
               val entries = entityOutputFields.zip(keyTokens).map: (f, key) =>
                 s"\t\t\t${key.padTo(keyWidth, ' ')} ${StateBridgeGo.fromDafnyExpr(f, "out")},"

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -5,7 +5,6 @@ import specrest.codegen.Compose
 import specrest.codegen.DafnyKernel
 import specrest.codegen.EmitOptions
 import specrest.codegen.EmitShared
-import specrest.codegen.SensitiveFields
 import specrest.codegen.EmittedFile
 import specrest.codegen.EnvExample
 import specrest.codegen.ExtensionStub
@@ -16,6 +15,7 @@ import specrest.codegen.RenderContext
 import specrest.codegen.ScalarOpView
 import specrest.codegen.ScalarOps
 import specrest.codegen.ScalarStateFieldView
+import specrest.codegen.SensitiveFields
 import specrest.codegen.TemplateEngine
 import specrest.codegen.migration.MigrationPlan
 import specrest.codegen.migration.SchemaCodec

--- a/modules/codegen/src/main/scala/specrest/codegen/go/StateBridgeGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/StateBridgeGo.scala
@@ -55,14 +55,14 @@ object StateBridgeGo:
         case "int64"     => s"dafnykernel.IntToDafny($access)"
         case "time.Time" => s"dafnykernel.IntToDafny($access.Unix())"
         case _           => access
-  private def fromDafnyExpr(f: ProfiledField, valueRef: String): String =
+  private[codegen] def fromDafnyExpr(f: ProfiledField, valueRef: String): String =
     val access = s"$valueRef.Dtor_${dafnyName(f.fieldName)}()"
     if f.nullable then
       f.domainType.stripPrefix("*") match
-        case "string"    => s"dafnykernel.OptStringFromDafny($access.(dafnykernel.Option))"
-        case "int64"     => s"dafnykernel.OptIntFromDafny($access.(dafnykernel.Option))"
-        case "time.Time" => s"dafnykernel.OptTimeFromDafny($access.(dafnykernel.Option))"
-        case "bool"      => s"dafnykernel.OptBoolFromDafny($access.(dafnykernel.Option))"
+        case "string"    => s"dafnykernel.OptStringFromDafny($access)"
+        case "int64"     => s"dafnykernel.OptIntFromDafny($access)"
+        case "time.Time" => s"dafnykernel.OptTimeFromDafny($access)"
+        case "bool"      => s"dafnykernel.OptBoolFromDafny($access)"
         case _           => access
     else
       f.domainType match
@@ -132,16 +132,18 @@ object StateBridgeGo:
       persist ++= "\t\treturn err\n\t}\n"
       persist ++= s"\t$existing := make(map[$keyType]models.${e.modelClassName}, len($rows))\n"
       persist ++= s"\tfor _, r := range $rows {\n\t\t$existing[r.$keyGo] = r\n\t}\n"
-      persist ++= s"\tseen := make(map[$keyType]bool)\n"
-      persist ++= s"\tit := st.${stateFieldName(r.stateField)}.Items().Iterator()\n"
-      persist ++= "\tfor tu, ok := it(); ok; tu, ok = it() {\n"
+      val seen = Naming.toCamelCase(e.entityName, Naming.CamelStrategy.Plain) + "Seen"
+      val iter = Naming.toCamelCase(e.entityName, Naming.CamelStrategy.Plain) + "It"
+      persist ++= s"\t$seen := make(map[$keyType]bool)\n"
+      persist ++= s"\t$iter := st.${stateFieldName(r.stateField)}.Items().Iterator()\n"
+      persist ++= s"\tfor tu, ok := $iter(); ok; tu, ok = $iter() {\n"
       persist ++= "\t\tpair := tu.(_dafny.Tuple)\n"
       val keyExpr = keyType match
         case "string" => "dafnykernel.StringFromDafny((*pair.IndexInt(0)).(_dafny.Sequence))"
         case _        => "dafnykernel.IntFromDafny((*pair.IndexInt(0)).(_dafny.Int))"
       persist ++= s"\t\tkey := $keyExpr\n"
       persist ++= s"\t\tvalue := (*pair.IndexInt(1)).(dafnykernel.${e.entityName})\n"
-      persist ++= "\t\tseen[key] = true\n"
+      persist ++= s"\t\t$seen[key] = true\n"
       persist ++= s"\t\trow, exists := $existing[key]\n"
       // The key column stays immutable on updates (the row was fetched by it,
       // and rewriting it from the Dafny value could desync row identity from
@@ -158,7 +160,7 @@ object StateBridgeGo:
       persist ++= "\t\t}\n"
       persist ++= "\t}\n"
       persist ++= s"\tfor key := range $existing {\n"
-      persist ++= "\t\tif !seen[key] {\n"
+      persist ++= s"\t\tif !$seen[key] {\n"
       persist ++= s"\t\t\trow := $existing[key]\n"
       persist ++= "\t\t\tif _, err := db.NewDelete().Model(&row).WherePK().Exec(ctx); err != nil {\n"
       persist ++= "\t\t\t\treturn err\n\t\t\t}\n"

--- a/modules/codegen/src/main/scala/specrest/codegen/go/StateBridgeGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/StateBridgeGo.scala
@@ -20,8 +20,10 @@ object StateBridgeGo:
   def plan(profiled: ProfiledService): Either[String, StatePlan.Plan] =
     StatePlan.analyze(
       profiled,
-      fieldSupported = f => ScalarGoTypes.contains(f.domainType) && !f.nullable,
-      keySupported = k => Set("string", "int64").contains(k.domainType) && !k.nullable
+      // Nullable go fields carry the pointer spelling in domainType.
+      fieldSupported = f => ScalarGoTypes.contains(f.domainType.stripPrefix("*")),
+      keySupported = k => Set("string", "int64").contains(k.domainType) && !k.nullable,
+      seqSupported = true
     )
 
   private def pascal(name: String): String =
@@ -40,18 +42,34 @@ object StateBridgeGo:
 
   private def toDafnyExpr(f: ProfiledField, rowRef: String): String =
     val access = s"$rowRef.${pascal(f.fieldName)}"
-    f.domainType match
-      case "string"    => s"dafnykernel.StringToDafny($access)"
-      case "int64"     => s"dafnykernel.IntToDafny($access)"
-      case "time.Time" => s"dafnykernel.IntToDafny($access.Unix())"
-      case _           => access
+    if f.nullable then
+      f.domainType.stripPrefix("*") match
+        case "string"    => s"dafnykernel.OptStringToDafny($access)"
+        case "int64"     => s"dafnykernel.OptIntToDafny($access)"
+        case "time.Time" => s"dafnykernel.OptTimeToDafny($access)"
+        case "bool"      => s"dafnykernel.OptBoolToDafny($access)"
+        case _           => access
+    else
+      f.domainType match
+        case "string"    => s"dafnykernel.StringToDafny($access)"
+        case "int64"     => s"dafnykernel.IntToDafny($access)"
+        case "time.Time" => s"dafnykernel.IntToDafny($access.Unix())"
+        case _           => access
   private def fromDafnyExpr(f: ProfiledField, valueRef: String): String =
     val access = s"$valueRef.Dtor_${dafnyName(f.fieldName)}()"
-    f.domainType match
-      case "string"    => s"dafnykernel.StringFromDafny($access)"
-      case "int64"     => s"dafnykernel.IntFromDafny($access)"
-      case "time.Time" => s"time.Unix(dafnykernel.IntFromDafny($access), 0).UTC()"
-      case _           => access
+    if f.nullable then
+      f.domainType.stripPrefix("*") match
+        case "string"    => s"dafnykernel.OptStringFromDafny($access.(dafnykernel.Option))"
+        case "int64"     => s"dafnykernel.OptIntFromDafny($access.(dafnykernel.Option))"
+        case "time.Time" => s"dafnykernel.OptTimeFromDafny($access.(dafnykernel.Option))"
+        case "bool"      => s"dafnykernel.OptBoolFromDafny($access.(dafnykernel.Option))"
+        case _           => access
+    else
+      f.domainType match
+        case "string"    => s"dafnykernel.StringFromDafny($access)"
+        case "int64"     => s"dafnykernel.IntFromDafny($access)"
+        case "time.Time" => s"time.Unix(dafnykernel.IntFromDafny($access), 0).UTC()"
+        case _           => access
 
   private def keyToDafny(key: ProfiledField, rowRef: String): String =
     key.domainType match
@@ -63,18 +81,32 @@ object StateBridgeGo:
       case Right(p) => p
       case Left(_)  => StatePlan.Plan(Nil, Nil)
 
-    val entities   = planned.relations.map(_.entity).distinctBy(_.entityName)
-    val needsTime  = entities.exists(_.fields.exists(_.domainType == "time.Time"))
+    val entities = planned.relations.map(_.entity).distinctBy(_.entityName)
+    val needsTime =
+      entities.exists(_.fields.exists(_.domainType.stripPrefix("*") == "time.Time"))
     val timeImport = if needsTime then "\n\t\"time\"" else ""
     val scalarImports =
       if planned.scalars.isEmpty then ""
       else "\n\t\"database/sql\"\n\t\"errors\""
 
-    val hydrate = new StringBuilder
+    val seqRelations = planned.relations.filter(_.isSeq)
+    val seqEntities  = seqRelations.map(_.entity.entityName).toSet
+    val hydrate      = new StringBuilder
     for e <- entities do
+      val order =
+        if seqEntities.contains(e.entityName) then ".Order(\"id ASC\")" else ""
       hydrate ++= s"\t${rowsVar(e)} := make([]models.${e.modelClassName}, 0)\n"
-      hydrate ++= s"\tif err := db.NewSelect().Model(&${rowsVar(e)}).Scan(ctx); err != nil {\n"
+      hydrate ++= s"\tif err := db.NewSelect().Model(&${rowsVar(e)})$order.Scan(ctx); err != nil {\n"
       hydrate ++= "\t\treturn nil, err\n\t}\n"
+    for r <- seqRelations do
+      // Rows ordered by the serial pk are the seq, element order preserved.
+      val elems = Naming.toCamelCase(r.stateField, Naming.CamelStrategy.Plain) + "Elems"
+      hydrate ++= s"\t$elems := make([]interface{}, 0, len(${rowsVar(r.entity)}))\n"
+      hydrate ++= s"\tfor _, r := range ${rowsVar(r.entity)} {\n"
+      val args = r.entity.fields.map(f => s"\t\t\t${toDafnyExpr(f, "r")},").mkString("\n")
+      hydrate ++= s"\t\t$elems = append($elems, dafnykernel.Companion_${r.entity.entityName}_.Create_${r.entity.entityName}_(\n$args\n\t\t))\n"
+      hydrate ++= "\t}\n"
+      hydrate ++= s"\tst.${stateFieldName(r.stateField)} = _dafny.SeqOf($elems...)\n"
     for (r, rKey) <- planned.relations.flatMap(r => r.keyField.map(r -> _)) do
       val builder = Naming.toCamelCase(r.stateField, Naming.CamelStrategy.Plain) + "Builder"
       hydrate ++= s"\t$builder := _dafny.NewMapBuilder()\n"
@@ -131,6 +163,22 @@ object StateBridgeGo:
       persist ++= "\t\t\tif _, err := db.NewDelete().Model(&row).WherePK().Exec(ctx); err != nil {\n"
       persist ++= "\t\t\t\treturn err\n\t\t\t}\n"
       persist ++= "\t\t}\n\t}\n"
+    for r <- seqRelations do
+      val e     = r.entity
+      val snake = Naming.toCamelCase(e.entityName, Naming.CamelStrategy.Plain)
+      // Reinsert in seq order: the serial pk reassigns, which nothing
+      // observes (the seq projection orders by it and exposes no id).
+      persist ++= s"\tif _, err := db.NewDelete().Model((*models.${e.modelClassName})(nil)).Where(\"1 = 1\").Exec(ctx); err != nil {\n"
+      persist ++= "\t\treturn err\n\t}\n"
+      persist ++= s"\tit${snake} := _dafny.Iterate(st.${stateFieldName(r.stateField)})\n"
+      persist ++= s"\tfor elem, ok := it${snake}(); ok; elem, ok = it${snake}() {\n"
+      persist ++= s"\t\tvalue := elem.(dafnykernel.${e.entityName})\n"
+      persist ++= s"\t\trow := models.${e.modelClassName}{}\n"
+      for f <- e.fields do
+        persist ++= s"\t\trow.${pascal(f.fieldName)} = ${fromDafnyExpr(f, "value")}\n"
+      persist ++= "\t\tif _, err := db.NewInsert().Model(&row).Exec(ctx); err != nil {\n"
+      persist ++= "\t\t\treturn err\n\t\t}\n"
+      persist ++= "\t}\n"
     if planned.scalars.nonEmpty then
       persist ++= "\tscalarRow := new(models.ServiceState)\n"
       persist ++= "\terr := db.NewSelect().Model(scalarRow).Where(\"id = 1\").Limit(1).Scan(ctx)\n"

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -76,6 +76,7 @@ final private case class TsOperation(
     dafnyMethod: Option[String],
     routeThroughKernel: Boolean,
     kernelServiceFn: String,
+    kernelNoResult: Boolean,
     kernelCandidateConsts: List[(String, String)],
     kernelRouteCallArgs: String,
     authMiddleware: Option[String],
@@ -980,6 +981,7 @@ object EmitTs:
       dafnyMethod = op.dafnyMethod,
       routeThroughKernel = kernelFn.isDefined,
       kernelServiceFn = kernelFn.map(_._1).getOrElse(""),
+      kernelNoResult = kernelFn.exists(_._1.contains("): Promise<void>")),
       kernelCandidateConsts = kernelFn
         .map(_ =>
           op.dafnyCandidates.map(c => tsCandidateCharsetConst(c.param) -> c.sampleCharset)
@@ -1020,8 +1022,10 @@ object EmitTs:
   private def tsCandidateCharsetConst(param: String): String =
     toCamelCase(param) + "Charset"
 
+  // Kernel entity projections must key exactly like the read DTOs, including
+  // the TS reserved-identifier escaping.
   private def camelName(name: String): String =
-    Naming.toCamelCase(name, Naming.CamelStrategy.Plain)
+    Naming.toCamelCase(name, Naming.CamelStrategy.Ts)
 
   private def tsKernelServiceFn(
       op: ProfiledOperation,

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -14,6 +14,7 @@ import specrest.codegen.RenderContext
 import specrest.codegen.ScalarOpView
 import specrest.codegen.ScalarOps
 import specrest.codegen.ScalarStateFieldView
+import specrest.codegen.SensitiveFields
 import specrest.codegen.TemplateEngine
 import specrest.codegen.TsTemplates
 import specrest.codegen.migration.MigrationPlan
@@ -180,7 +181,9 @@ object EmitTs:
     val entities = profiled.entities.map: entity =>
       val entityOps = profiled.operations
         .filter(_.targetEntity.contains(entity.entityName))
-        .map(op => enrichOperation(op, entity, typeLookup, db.nativeAttrs, kernelCtx))
+        .map(op =>
+          enrichOperation(op, entity, profiled.entities, typeLookup, db.nativeAttrs, kernelCtx)
+        )
         .sortWith((a, b) => EmitShared.byPathSpecificity(a.path, b.path))
       val maintained = triggerMaintainedByTable.getOrElse(entity.tableName, Set.empty)
       buildEntityCtx(
@@ -676,8 +679,10 @@ object EmitTs:
           "intToDafny",
           "makeState",
           "sampleCandidate",
+          "someOrNone",
           "stringFromDafny",
-          "stringToDafny"
+          "stringToDafny",
+          "valueOrNull"
         ).filter(n => fns.contains(n + "(") || fns.contains(n + "."))
         val lines = List.newBuilder[String]
         if fns.contains("HttpError(") then
@@ -801,6 +806,7 @@ object EmitTs:
   private def enrichOperation(
       op: ProfiledOperation,
       entity: ProfiledEntity,
+      allEntities: List[ProfiledEntity],
       typeLookup: Map[String, String],
       nativeAttrs: Boolean,
       kernelCtx: TsKernelCtx
@@ -948,6 +954,7 @@ object EmitTs:
         EmitShared.routeKindName(routeKind),
         hasRequestBody,
         requestBodyType,
+        allEntities,
         typeLookup,
         kernelCtx
       )
@@ -1013,12 +1020,16 @@ object EmitTs:
   private def tsCandidateCharsetConst(param: String): String =
     toCamelCase(param) + "Charset"
 
+  private def camelName(name: String): String =
+    Naming.toCamelCase(name, Naming.CamelStrategy.Plain)
+
   private def tsKernelServiceFn(
       op: ProfiledOperation,
       handlerName: String,
       routeKind: String,
       hasRequestBody: Boolean,
       requestBodyType: String,
+      allEntities: List[ProfiledEntity],
       typeLookup: Map[String, String],
       kernelCtx: TsKernelCtx
   ): Option[(String, String)] =
@@ -1036,8 +1047,31 @@ object EmitTs:
         tsKernelScalarConv.get(tsType).map: (toDafny, _) =>
           if toDafny.isEmpty then access else s"$toDafny($access)"
       val outputs = op.responseFields
+      val specOutputs = svcOperations(kernelCtx.ir)
+        .find(o => operName(o) == op.operationName)
+        .map(operOutputs)
+        .getOrElse(Nil)
+      // Mirrors the python and go marshalling: no outputs is a plain effect
+      // call, a single entity output projects the read shape flat, scalars
+      // unpack positionally.
+      val entityOutput = specOutputs match
+        case single :: Nil =>
+          prmType(single) match
+            case NamedTypeF(n, _) => allEntities.find(_.entityName == n)
+            case _                => None
+        case _ => None
+      val entityOutputFields = entityOutput
+        .map(_.fields.filterNot(f => SensitiveFields.isSensitive(f.columnName)))
+        .getOrElse(Nil)
+      val tsEntityTypes = Set("string", "number", "boolean", "Date")
       val outputsOk =
-        outputs.nonEmpty && outputs.forall(f => tsKernelScalarConv.contains(f.domainType))
+        if specOutputs.isEmpty then true
+        else if entityOutput.isDefined then
+          entityOutputFields.nonEmpty &&
+          entityOutputFields.forall(f =>
+            tsEntityTypes.contains(f.domainType.replaceAll("\\s*\\|\\s*null$", ""))
+          )
+        else outputs.nonEmpty && outputs.forall(f => tsKernelScalarConv.contains(f.domainType))
       // A redirect op's route issues `res.redirect(status, result)`, so the kernel result must be a
       // single string (the redirect target); otherwise leave it to the redirect route-kind branch.
       val redirectOk =
@@ -1055,28 +1089,41 @@ object EmitTs:
         def fromDafny(f: ProfiledField, v: String): String =
           val conv = tsKernelScalarConv(f.domainType)._2
           if conv.isEmpty then v else s"$conv($v)"
+        // The state wrapper splices persistState before the LAST body line,
+        // so every shape ends on exactly one return statement.
+        val noResult = specOutputs.isEmpty
         val (returnType, bodyLines) =
-          outputs match
-            case single :: Nil =>
-              val v = "out" + toPascalCase(single.fieldName)
-              (
-                single.domainType,
-                List(s"  const $v = $call;", s"  return ${fromDafny(single, v)};")
-              )
-            case many =>
-              val vars = many.map(f => "out" + toPascalCase(f.fieldName))
-              val typeBody =
-                many.map(f => s"${toCamelCase(f.fieldName)}: ${f.domainType}").mkString("; ")
-              val unknowns = List.fill(vars.size)("unknown").mkString(", ")
-              val retFields =
-                many.zip(vars).map((f, v) => s"${toCamelCase(f.fieldName)}: ${fromDafny(f, v)}")
-              (
-                s"{ $typeBody }",
-                List(
-                  s"  const [${vars.mkString(", ")}] = $call as [$unknowns];",
-                  s"  return { ${retFields.mkString(", ")} };"
+          if noResult then ("void", List(s"  $call;", "  return;"))
+          else if entityOutput.isDefined then
+            val pairs = entityOutputFields.map: f =>
+              s"    ${camelName(f.fieldName)}: ${StateBridgeTs.fromDafnyExpr(f, "out")},"
+            (
+              "Record<string, unknown>",
+              (s"  const out = $call as Record<string, unknown>;" ::
+                "  const result = {" :: pairs) ::: List("  };", "  return result;")
+            )
+          else
+            outputs match
+              case single :: Nil =>
+                val v = "out" + toPascalCase(single.fieldName)
+                (
+                  single.domainType,
+                  List(s"  const $v = $call;", s"  return ${fromDafny(single, v)};")
                 )
-              )
+              case many =>
+                val vars = many.map(f => "out" + toPascalCase(f.fieldName))
+                val typeBody =
+                  many.map(f => s"${toCamelCase(f.fieldName)}: ${f.domainType}").mkString("; ")
+                val unknowns = List.fill(vars.size)("unknown").mkString(", ")
+                val retFields =
+                  many.zip(vars).map((f, v) => s"${toCamelCase(f.fieldName)}: ${fromDafny(f, v)}")
+                (
+                  s"{ $typeBody }",
+                  List(
+                    s"  const [${vars.mkString(", ")}] = $call as [$unknowns];",
+                    s"  return { ${retFields.mkString(", ")} };"
+                  )
+                )
         val guardStatus = routeKind match
           case "read" | "redirect" | "delete" => 404
           case _                              => 409

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
@@ -17,10 +17,14 @@ object StateBridgeTs:
   def plan(profiled: ProfiledService): Either[String, StatePlan.Plan] =
     StatePlan.analyze(
       profiled,
-      fieldSupported = f => ScalarTsTypes.contains(f.domainType),
+      // Nullable ts fields carry the union spelling in domainType.
+      fieldSupported = f => ScalarTsTypes.contains(baseTs(f.domainType)),
       keySupported = k => Set("string", "number").contains(k.domainType) && !k.nullable,
       seqSupported = true
     )
+
+  private def baseTs(domainType: String): String =
+    domainType.replaceAll("\\s*\\|\\s*null$", "").trim
 
   private def camel(name: String): String =
     Naming.toCamelCase(name, Naming.CamelStrategy.Plain)
@@ -30,7 +34,7 @@ object StateBridgeTs:
   private def toDafnyExpr(f: ProfiledField, rowRef: String): String =
     val access = s"$rowRef.${camel(f.fieldName)}"
     if f.nullable then
-      f.domainType match
+      baseTs(f.domainType) match
         case "string" => s"someOrNone($access, (v) => stringToDafny(v as string))"
         case "number" => s"someOrNone($access, (v) => intToDafny(v as number))"
         case "Date" =>
@@ -43,14 +47,15 @@ object StateBridgeTs:
         case "Date"   => s"intToDafny(Math.floor($access.getTime() / 1000))"
         case _        => access
 
-  private def fromDafnyExpr(f: ProfiledField, valueRef: String): String =
+  private[codegen] def fromDafnyExpr(f: ProfiledField, valueRef: String): String =
     val access = s"$valueRef['dtor_${dafnyName(f.fieldName)}']"
     if f.nullable then
-      f.domainType match
-        case "string" => s"valueOrNull($access, (v) => stringFromDafny(v))"
-        case "number" => s"valueOrNull($access, (v) => intFromDafny(v))"
-        case "Date"   => s"valueOrNull($access, (v) => new Date(intFromDafny(v) * 1000))"
-        case _        => s"valueOrNull($access, (v) => v)"
+      baseTs(f.domainType) match
+        case "string" => s"(valueOrNull($access, (v) => stringFromDafny(v)) as string | null)"
+        case "number" => s"(valueOrNull($access, (v) => intFromDafny(v)) as number | null)"
+        case "Date" =>
+          s"(valueOrNull($access, (v) => new Date(intFromDafny(v) * 1000)) as Date | null)"
+        case _ => s"(valueOrNull($access, (v) => v) as boolean | null)"
     else
       f.domainType match
         case "string" => s"stringFromDafny($access)"
@@ -106,7 +111,8 @@ object StateBridgeTs:
       hydrate ++= "  const scalarRow = await tx.serviceState.findUnique({ where: { id: 1 } });\n"
       hydrate ++= "  if (scalarRow) {\n"
       for sc <- planned.scalars do
-        hydrate ++= s"    st['${dafnyName(sc.stateField)}'] = intToDafny(scalarRow.${camel(sc.columnName)});\n"
+        // Prisma types BIGINT columns as bigint; the adapter takes number.
+        hydrate ++= s"    st['${dafnyName(sc.stateField)}'] = intToDafny(Number(scalarRow.${camel(sc.columnName)}));\n"
       hydrate ++= "  }\n"
 
     val persist = new StringBuilder
@@ -127,12 +133,17 @@ object StateBridgeTs:
       val e      = r.entity
       val client = camel(e.entityName)
       persist ++= s"  const ${client}Rows = await tx.$client.findMany();\n"
-      persist ++= s"  const ${client}Existing = new Map(${client}Rows.map((r) => [r.${camel(rKey.fieldName)}, r]));\n"
-      persist ++= s"  const seen = new Set<${rKey.domainType}>();\n"
+      // Prisma BigInt pks come back as bigint while the dafny-side keys are
+      // numbers, so numeric lookup keys coerce; string keys pass through.
+      val mapKey =
+        if rKey.domainType == "string" then s"r.${camel(rKey.fieldName)}"
+        else s"Number(r.${camel(rKey.fieldName)})"
+      persist ++= s"  const ${client}Existing = new Map(${client}Rows.map((r) => [$mapKey, r]));\n"
+      persist ++= s"  const ${client}Seen = new Set<${rKey.domainType}>();\n"
       persist ++= s"  for (const [k, v] of st['${dafnyName(r.stateField)}'] as Iterable<[unknown, unknown]>) {\n"
       persist ++= s"    const key = ${keyFromDafny(rKey)};\n"
       persist ++= "    const value = v as Record<string, unknown>;\n"
-      persist ++= "    seen.add(key);\n"
+      persist ++= s"    ${client}Seen.add(key);\n"
       val nonKey = e.fields.filter(_.fieldName != rKey.fieldName)
       persist ++= "    const data = {\n"
       for f <- nonKey do
@@ -148,7 +159,7 @@ object StateBridgeTs:
       persist ++= "    }\n"
       persist ++= "  }\n"
       persist ++= s"  for (const [key, row] of ${client}Existing) {\n"
-      persist ++= "    if (!seen.has(key)) {\n"
+      persist ++= s"    if (!${client}Seen.has(key)) {\n"
       persist ++= s"      await tx.$client.delete({ where: { id: row.id } });\n"
       persist ++= "    }\n"
       persist ++= "  }\n"
@@ -163,16 +174,22 @@ object StateBridgeTs:
       persist ++= "    create: { id: 1, ...scalarData },\n"
       persist ++= "  });\n"
 
+    val adapterNames = (List(
+      "dafnyModule",
+      "emptyDafnyMap",
+      "intFromDafny",
+      "intToDafny",
+      "makeState",
+      "stringFromDafny",
+      "stringToDafny"
+    ) ::: (if seqRelations.nonEmpty then List("dafnySeqOf") else Nil)
+      ::: (if planned.relations.exists(_.entity.fields.exists(_.nullable)) then
+             List("someOrNone", "valueOrNull")
+           else Nil)).sorted
     s"""import type { Prisma } from '@prisma/client';
        |
        |import {
-       |  dafnyModule,
-       |  emptyDafnyMap,
-       |  intFromDafny,
-       |  intToDafny,
-       |  makeState,
-       |  stringFromDafny,
-       |  stringToDafny,
+       |${adapterNames.map(n => s"  $n,").mkString("\n")}
        |} from '../dafnyKernel/adapter.js';
        |
        |type DafnyMap = { update(k: unknown, v: unknown): DafnyMap } & Iterable<[unknown, unknown]>;

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
@@ -14,13 +14,12 @@ object StateBridgeTs:
 
   private val ScalarTsTypes = Set("string", "number", "boolean", "Date")
 
-  // Nullable fields would need Option constructors on the Dafny side; the
-  // gate keeps them out until a spec actually needs them in ts.
   def plan(profiled: ProfiledService): Either[String, StatePlan.Plan] =
     StatePlan.analyze(
       profiled,
-      fieldSupported = f => ScalarTsTypes.contains(f.domainType) && !f.nullable,
-      keySupported = k => Set("string", "number").contains(k.domainType) && !k.nullable
+      fieldSupported = f => ScalarTsTypes.contains(f.domainType),
+      keySupported = k => Set("string", "number").contains(k.domainType) && !k.nullable,
+      seqSupported = true
     )
 
   private def camel(name: String): String =
@@ -30,19 +29,34 @@ object StateBridgeTs:
 
   private def toDafnyExpr(f: ProfiledField, rowRef: String): String =
     val access = s"$rowRef.${camel(f.fieldName)}"
-    f.domainType match
-      case "string" => s"stringToDafny($access)"
-      case "number" => s"intToDafny($access)"
-      case "Date"   => s"intToDafny(Math.floor($access.getTime() / 1000))"
-      case _        => access
+    if f.nullable then
+      f.domainType match
+        case "string" => s"someOrNone($access, (v) => stringToDafny(v as string))"
+        case "number" => s"someOrNone($access, (v) => intToDafny(v as number))"
+        case "Date" =>
+          s"someOrNone($access, (v) => intToDafny(Math.floor((v as Date).getTime() / 1000)))"
+        case _ => s"someOrNone($access, (v) => v)"
+    else
+      f.domainType match
+        case "string" => s"stringToDafny($access)"
+        case "number" => s"intToDafny($access)"
+        case "Date"   => s"intToDafny(Math.floor($access.getTime() / 1000))"
+        case _        => access
 
   private def fromDafnyExpr(f: ProfiledField, valueRef: String): String =
     val access = s"$valueRef['dtor_${dafnyName(f.fieldName)}']"
-    f.domainType match
-      case "string" => s"stringFromDafny($access)"
-      case "number" => s"intFromDafny($access)"
-      case "Date"   => s"new Date(intFromDafny($access) * 1000)"
-      case _        => s"($access as boolean)"
+    if f.nullable then
+      f.domainType match
+        case "string" => s"valueOrNull($access, (v) => stringFromDafny(v))"
+        case "number" => s"valueOrNull($access, (v) => intFromDafny(v))"
+        case "Date"   => s"valueOrNull($access, (v) => new Date(intFromDafny(v) * 1000))"
+        case _        => s"valueOrNull($access, (v) => v)"
+    else
+      f.domainType match
+        case "string" => s"stringFromDafny($access)"
+        case "number" => s"intFromDafny($access)"
+        case "Date"   => s"new Date(intFromDafny($access) * 1000)"
+        case _        => s"($access as boolean)"
 
   private def keyToDafny(key: ProfiledField, rowRef: String): String =
     key.domainType match
@@ -59,11 +73,22 @@ object StateBridgeTs:
       case Right(p) => p
       case Left(_)  => StatePlan.Plan(Nil, Nil)
 
-    val entities = planned.relations.map(_.entity).distinctBy(_.entityName)
+    val entities     = planned.relations.map(_.entity).distinctBy(_.entityName)
+    val seqRelations = planned.relations.filter(_.isSeq)
+    val seqEntities  = seqRelations.map(_.entity.entityName).toSet
 
     val hydrate = new StringBuilder
     for e <- entities do
-      hydrate ++= s"  const ${camel(e.entityName)}Rows = await tx.${camel(e.entityName)}.findMany();\n"
+      val order =
+        if seqEntities.contains(e.entityName) then "{ orderBy: { id: 'asc' } }" else ""
+      hydrate ++= s"  const ${camel(e.entityName)}Rows = await tx.${camel(e.entityName)}.findMany($order);\n"
+    for r <- seqRelations do
+      // Rows ordered by the serial pk are the seq, element order preserved.
+      val rows = s"${camel(r.entity.entityName)}Rows"
+      val args = r.entity.fields.map(f => s"      ${toDafnyExpr(f, "r")},").mkString("\n")
+      hydrate ++= s"  st['${dafnyName(r.stateField)}'] = dafnySeqOf(${rows}.map((r) =>\n"
+      hydrate ++= s"    dafnyModule['${r.entity.entityName}'].create_${r.entity.entityName}(\n$args\n    ),\n"
+      hydrate ++= "  ));\n"
     for (r, rKey) <- planned.relations.flatMap(r => r.keyField.map(r -> _)) do
       val rows    = s"${camel(r.entity.entityName)}Rows"
       val builder = s"${camel(r.stateField)}Map"
@@ -85,6 +110,19 @@ object StateBridgeTs:
       hydrate ++= "  }\n"
 
     val persist = new StringBuilder
+    for r <- seqRelations do
+      val e      = r.entity
+      val client = camel(e.entityName)
+      // Reinsert in seq order: the serial pk reassigns, which nothing
+      // observes (the seq projection orders by it and exposes no id).
+      persist ++= s"  await tx.$client.deleteMany();\n"
+      persist ++= s"  for (const v of st['${dafnyName(r.stateField)}'] as Iterable<unknown>) {\n"
+      persist ++= "    const value = v as Record<string, unknown>;\n"
+      persist ++= s"    await tx.$client.create({\n      data: {\n"
+      for f <- e.fields do
+        persist ++= s"        ${camel(f.fieldName)}: ${fromDafnyExpr(f, "value")},\n"
+      persist ++= "      },\n    });\n"
+      persist ++= "  }\n"
     for (r, rKey) <- planned.entityRowRelations.flatMap(r => r.keyField.map(r -> _)) do
       val e      = r.entity
       val client = camel(e.entityName)

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
@@ -111,8 +111,7 @@ object StateBridgeTs:
       hydrate ++= "  const scalarRow = await tx.serviceState.findUnique({ where: { id: 1 } });\n"
       hydrate ++= "  if (scalarRow) {\n"
       for sc <- planned.scalars do
-        // Prisma types BIGINT columns as bigint; the adapter takes number.
-        hydrate ++= s"    st['${dafnyName(sc.stateField)}'] = intToDafny(Number(scalarRow.${camel(sc.columnName)}));\n"
+        hydrate ++= s"    st['${dafnyName(sc.stateField)}'] = intToDafny(scalarRow.${camel(sc.columnName)});\n"
       hydrate ++= "  }\n"
 
     val persist = new StringBuilder
@@ -133,15 +132,14 @@ object StateBridgeTs:
       val e      = r.entity
       val client = camel(e.entityName)
       persist ++= s"  const ${client}Rows = await tx.$client.findMany();\n"
-      // Prisma BigInt pks come back as bigint while the dafny-side keys are
-      // numbers, so numeric lookup keys coerce; string keys pass through.
-      val mapKey =
-        if rKey.domainType == "string" then s"r.${camel(rKey.fieldName)}"
-        else s"Number(r.${camel(rKey.fieldName)})"
-      persist ++= s"  const ${client}Existing = new Map(${client}Rows.map((r) => [$mapKey, r]));\n"
-      persist ++= s"  const ${client}Seen = new Set<${rKey.domainType}>();\n"
+      // String-typed lookup keys are exact for every magnitude: prisma pks
+      // arrive as bigint and dafny keys convert through number, so comparing
+      // their canonical string forms avoids both bigint mismatch and float
+      // precision loss on large ids.
+      persist ++= s"  const ${client}Existing = new Map(${client}Rows.map((r) => [String(r.${camel(rKey.fieldName)}), r]));\n"
+      persist ++= s"  const ${client}Seen = new Set<string>();\n"
       persist ++= s"  for (const [k, v] of st['${dafnyName(r.stateField)}'] as Iterable<[unknown, unknown]>) {\n"
-      persist ++= s"    const key = ${keyFromDafny(rKey)};\n"
+      persist ++= s"    const key = String(${keyFromDafny(rKey)});\n"
       persist ++= "    const value = v as Record<string, unknown>;\n"
       persist ++= s"    ${client}Seen.add(key);\n"
       val nonKey = e.fields.filter(_.fieldName != rKey.fieldName)

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
@@ -68,11 +68,6 @@ object StateBridgeTs:
       case "string" => s"stringToDafny($rowRef.${camel(key.fieldName)})"
       case _        => s"intToDafny($rowRef.${camel(key.fieldName)})"
 
-  private def keyFromDafny(key: ProfiledField): String =
-    key.domainType match
-      case "string" => "stringFromDafny(k)"
-      case _        => "intFromDafny(k)"
-
   def emit(profiled: ProfiledService): String =
     val planned = plan(profiled) match
       case Right(p) => p
@@ -139,7 +134,9 @@ object StateBridgeTs:
       persist ++= s"  const ${client}Existing = new Map(${client}Rows.map((r) => [String(r.${camel(rKey.fieldName)}), r]));\n"
       persist ++= s"  const ${client}Seen = new Set<string>();\n"
       persist ++= s"  for (const [k, v] of st['${dafnyName(r.stateField)}'] as Iterable<[unknown, unknown]>) {\n"
-      persist ++= s"    const key = String(${keyFromDafny(rKey)});\n"
+      val dafnyKeyString =
+        if rKey.domainType == "string" then "stringFromDafny(k)" else "intKeyFromDafny(k)"
+      persist ++= s"    const key = $dafnyKeyString;\n"
       persist ++= "    const value = v as Record<string, unknown>;\n"
       persist ++= s"    ${client}Seen.add(key);\n"
       val nonKey = e.fields.filter(_.fieldName != rKey.fieldName)
@@ -181,6 +178,9 @@ object StateBridgeTs:
       "stringFromDafny",
       "stringToDafny"
     ) ::: (if seqRelations.nonEmpty then List("dafnySeqOf") else Nil)
+      ::: (if planned.entityRowRelations.exists(_.keyField.exists(_.domainType != "string")) then
+             List("intKeyFromDafny")
+           else Nil)
       ::: (if planned.relations.exists(_.entity.fields.exists(_.nullable)) then
              List("someOrNone", "valueOrNull")
            else Nil)).sorted

--- a/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_gen.go
+++ b/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_gen.go
@@ -11,7 +11,9 @@ package tests
 
 import (
 	"math"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"pgregory.net/rapid"
 )
@@ -20,7 +22,17 @@ func mapAny[T any](g *rapid.Generator[T]) *rapid.Generator[any] {
 	return rapid.Map(g, func(x T) any { return any(x) })
 }
 
-func genString() *rapid.Generator[any] { return mapAny(rapid.String()) }
+// Postgres text rejects NUL and MySQL utf8mb4 rejects lone surrogates; the
+// spec's semantics carry no encoding model, so generated strings exclude what
+// the storage layer categorically cannot hold (same policy as the python
+// suite's strategies).
+func storable(s string) bool {
+	return !strings.ContainsRune(s, 0x00) && utf8.ValidString(s)
+}
+
+func genString() *rapid.Generator[any] {
+	return mapAny(rapid.String().Filter(storable))
+}
 func genInt() *rapid.Generator[any]    { return mapAny(rapid.Int64()) }
 func genFloat() *rapid.Generator[any] {
 	return mapAny(rapid.Float64Range(-1e9, 1e9))
@@ -89,7 +101,7 @@ func genDict(kv ...any) *rapid.Generator[any] {
 func genRedact(inner *rapid.Generator[any]) *rapid.Generator[any] { return inner }
 
 func genStringMatching(pat string) *rapid.Generator[any] {
-	return mapAny(rapid.StringMatching(pat))
+	return mapAny(rapid.StringMatching(pat).Filter(storable))
 }
 
 func genStringBounded(minLen, maxLen int) *rapid.Generator[any] {
@@ -101,7 +113,7 @@ func genStringBounded(minLen, maxLen int) *rapid.Generator[any] {
 	if maxLen >= 0 {
 		hi = maxLen
 	}
-	return mapAny(rapid.StringN(lo, hi, -1))
+	return mapAny(rapid.StringN(lo, hi, -1).Filter(storable))
 }
 
 func genFilterLen(g *rapid.Generator[any], lo, hi int) *rapid.Generator[any] {

--- a/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
+++ b/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
@@ -13,6 +13,7 @@
 package tests
 
 import (
+	"strconv"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -142,7 +143,22 @@ func _eq(a, b any) bool {
 		if fb, okb := _toF(b); okb {
 			return fa == fb
 		}
+		// JSON object keys stringify, so an Int-keyed relation iterates as
+		// digit strings while ids stay numbers; compare numerically when the
+		// string side parses as a number exactly.
+		if sb, okb := b.(string); okb {
+			if fb, err := strconv.ParseFloat(sb, 64); err == nil {
+				return fa == fb
+			}
+		}
 		return false
+	}
+	if sa, oka := a.(string); oka {
+		if fb, okb := _toF(b); okb {
+			if fa, err := strconv.ParseFloat(sa, 64); err == nil {
+				return fa == fb
+			}
+		}
 	}
 	switch av := a.(type) {
 	case string:
@@ -214,9 +230,23 @@ func _in(x, c any) bool {
 	}
 }
 
+// Digit strings from JSON object keys compare numerically against numbers,
+// matching _eq's coercion (Int-keyed relations stringify their keys).
+func _num(x any) (float64, bool) {
+	if f, ok := _toF(x); ok {
+		return f, true
+	}
+	if s, ok := x.(string); ok {
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
+}
+
 func _cmp(a, b any) (int, bool) {
-	if fa, oka := _toF(a); oka {
-		if fb, okb := _toF(b); okb {
+	if fa, oka := _num(a); oka {
+		if fb, okb := _num(b); okb {
 			switch {
 			case fa < fb:
 				return -1, true

--- a/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
+++ b/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
@@ -231,7 +231,10 @@ func _in(x, c any) bool {
 }
 
 // Digit strings from JSON object keys compare numerically against numbers,
-// matching _eq's coercion (Int-keyed relations stringify their keys).
+// matching _eq's coercion (Int-keyed relations stringify their keys). The
+// float64 domain is the ceiling of the whole comparison anyway: encoding/json
+// decodes every number to float64 before these helpers ever see it, so a
+// ParseInt path would imply precision the decoded values no longer carry.
 func _num(x any) (float64, bool) {
 	if f, ok := _toF(x); ok {
 		return f, true

--- a/modules/testgen/src/main/scala/specrest/testgen/NativeSuites.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/NativeSuites.scala
@@ -297,4 +297,14 @@ private[testgen] object TsRender:
     val names =
       Strategies.forIR(ir, TsFastCheckStrategy).map(_.functionName).distinct.sorted
         .filter(n => scanText.contains(s"$n("))
-    Option.when(names.nonEmpty)(s"import { ${names.mkString(", ")} } from \"./_strategies.js\";\n")
+    val strategyLine =
+      Option.when(names.nonEmpty)(
+        s"import { ${names.mkString(", ")} } from \"./_strategies.js\";\n"
+      )
+    val redactLine =
+      Option.when(scanText.contains("redact("))(
+        "import { redact } from \"./_redaction.js\";\n"
+      )
+    (strategyLine, redactLine) match
+      case (None, None) => None
+      case (a, b)       => Some(a.getOrElse("") + b.getOrElse(""))

--- a/modules/testgen/src/main/scala/specrest/testgen/TestFormat.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestFormat.scala
@@ -44,9 +44,16 @@ private[testgen] object TestFormat:
     if params.isEmpty then Right(Nil)
     else
       val overrides = TestStrategyOverrides.from(ir)
+      val atoms = svcOperations(ir)
+        .find(o => operName(o) == pop.operationName)
+        .map(o => flattenEnsures(operRequires(o)))
+        .getOrElse(Nil)
       val pairs = params.map: p =>
         val sctx = StrategyCtx.OperationInput(pop.operationName, p.name)
-        (p.name, Strategies.expressionFor(p.typeExpr, ir, sctx, overrides, backend))
+        (
+          p.name,
+          Strategies.expressionForInput(p.typeExpr, ir, sctx, overrides, p.name, atoms, backend)
+        )
       pairs.collectFirst { case (n, StrategyExpr.Skip(r)) => s"input '$n': $r" } match
         case Some(reason) => Left(reason)
         case None         => Right(pairs.collect { case (n, StrategyExpr.Code(t)) => (n, t) })


### PR DESCRIPTION
Closes the first deferred item from #510: the go and ts state bridges now marshal everything auth's state needs, so its seven verified kernel bodies serve real traffic on all three targets instead of python alone. Nullable fields cross through typed Option helpers (go converts pointers via the kernel's Create_Some_/Create_None_ companions; ts goes through the kernel's own Option class with someOrNone/valueOrNull), and seq-valued state hydrates from pk-ordered rows into a Dafny sequence and persists by reinserting in order, on both targets, with the plan declaring seq support per bridge and failing closed where it is absent or where two projections would clobber one entity's table.

The kernel service marshalling grew the same three shapes python got last arc: output-less operations call and return nothing with the handler writing the bare success status, a single entity-valued output projects the entity's read shape flat with sensitive fields dropped, and scalar outputs stay as they were. Both emitters reuse their bridge's own conversion expressions, so Option fields surface as JSON null and datetimes come back from epoch ints identically in state and in responses.

Auth being first to exercise these paths shook out a batch of latent target-specific bugs, each now fixed at the emitter: go's duplicate := in multi-candidate sampling, function-scoped persist locals colliding across auth's five relations (both targets), handlebars' standalone-tag stripping eating go's import-group blank line (the stdlib group is now assembled in Scala), gofmt's struct column alignment on multi-scalar state, ts's nullable domainType union spelling silently failing the plan gate and stubbing every service, prisma's bigint pks versus the adapter's number, string-keyed relations being numerically coerced, and the transaction wrapper's persist splice demanding single-return kernel bodies.

The go and ts oracles also reached parity with python's honesty round: requires-derived length bounds now flow to every native target's rule strategies through one seam, go string generators filter to storable text (no NUL, valid UTF-8), comparisons coerce digit-string JSON keys numerically so Int-keyed invariants hold, and generated ts tests import redact when their strategies use it. Auth passes three consecutive live runs on each target.

Verified locally end to end: the full python regression batch (all four fixtures live on sqlite and postgres 17, url_shortener with synthesis, go and ts url_shortener live), then auth live with synthesis on go and ts. CI conformance rows for auth run with synthesis on both workflows; the build-only jobs keep plain rows. Remaining on #510: enum and collection marshalling for todo_list and ecommerce.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes auth kernels through new Go and TypeScript bridges with nullable fields and sequence state, matching Python. Aligns kernel output shapes (entity and empty) with read DTOs, and fixes lossless Dafny int key stringification to avoid precision issues.

- **New Features**
  - Go/TS state bridges: nullable via Option helpers; seq state (hydrate pk-ordered; persist in order).
  - Kernel service marshalling: no-output ops write status only; single-entity outputs project the read shape flat with sensitive fields removed and keys matching the read DTO (Go uses json tag names; TS uses escaped camel names); scalars unchanged. Option fields surface as JSON null; datetimes use epoch seconds.
  - TS adapter: adds `dafnySeqOf` (chunked concat for large hydrations), Option helpers, `intToDafny` accepts `bigint` from `@prisma/client`, and `intKeyFromDafny` renders Dafny ints losslessly for key comparisons.
  - Oracles/testgen: requires-derived length bounds flow to Go/TS; Go string generators emit storable UTF‑8; TS tests import `redact`. CI runs `auth_service` conformance with synthesis on Go and TS.

- **Bug Fixes**
  - Go: fix duplicate := in sampling; scope persist locals per entity; keep import-group spacing; pad struct tag columns for gofmt.
  - TS: recognize nullable union types; persist uses canonical string keys and lossless Dafny int key rendering (`intKeyFromDafny`) to avoid precision loss; kernel routes with no result call `res.end()`; import seq/option helpers where needed.
  - Comparisons: numeric checks handle digit-string JSON keys (Go explains float64 limits due to JSON decode).

<sup>Written for commit 5c2d5f65a74db852b12108b64d84afc1c89fe7fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated Go and TypeScript code now supports optional values more consistently, including nullable fields and richer option conversions.
  * Kernel-routed endpoints now handle operations with no returned result as well as entity-shaped results.

* **Bug Fixes**
  * Fixed conformance test matrix coverage for the `auth_service` sqlite setup.
  * Improved generated test data and runtime comparisons so strings are validated for storage compatibility and numeric strings compare correctly.

* **Refactor**
  * Updated code generation to produce cleaner imports, more stable ordering, and more consistent state hydration/persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->