### PR TITLE
fix(codegen): ts speaks snake_case on the JSON wire

### DIFF
--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/schema.prisma
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/schema.prisma
@@ -11,8 +11,8 @@ model UrlMapping {
   id BigInt @id @default(autoincrement())
   code String
   url String
-  createdAt DateTime @map("created_at")
-  clickCount Int @map("click_count")
+  created_at DateTime
+  click_count Int
 
   @@map("url_mappings")
 }

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/routes/admin.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/routes/admin.ts
@@ -19,8 +19,8 @@ function rowToDict_UrlMapping(r: Record<string, unknown>): Record<string, unknow
   return {
     code: r.code,
     url: r.url,
-    created_at: r.createdAt == null ? null : new Date(r.createdAt as string | Date).toISOString(),
-    click_count: r.clickCount,
+    created_at: r.created_at == null ? null : new Date(r.created_at as string | Date).toISOString(),
+    click_count: r.click_count,
   };
 }
 

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/schemas/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/schemas/urlMapping.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const UrlMappingCreateSchema = z.object({
   code: z.string().min(6).regex(/^(?:^[a-zA-Z0-9]+$)$/),
   url: z.string().min(1).regex(/^(?:^https?:\/\/[^\s\x00-\x1f\x7f]+)$/),
-  createdAt: z.coerce.date(),
-  clickCount: z.number(),
+  created_at: z.coerce.date(),
+  click_count: z.number(),
 });
 
 export type UrlMappingCreate = z.infer<typeof UrlMappingCreateSchema>;

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/types/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/types/urlMapping.ts
@@ -3,23 +3,23 @@ export interface UrlMapping {
   id: number;
   code: string;
   url: string;
-  createdAt: Date;
-  clickCount: number;
+  created_at: Date;
+  click_count: number;
 }
 
 export interface UrlMappingCreate {
   code: string;
   url: string;
-  createdAt: Date;
-  clickCount: number;
+  created_at: Date;
+  click_count: number;
 }
 
 export interface UrlMappingRead {
   id: number;
   code: string;
   url: string;
-  createdAt: Date;
-  clickCount: number;
+  created_at: Date;
+  click_count: number;
 }
 
 export interface ShortenRequest {

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/schema.prisma
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/schema.prisma
@@ -11,8 +11,8 @@ model UrlMapping {
   id BigInt @id @default(autoincrement()) @db.BigInt
   code String @db.Text
   url String @db.Text
-  createdAt DateTime @map("created_at") @db.Timestamptz()
-  clickCount Int @map("click_count") @db.Integer
+  created_at DateTime @db.Timestamptz()
+  click_count Int @db.Integer
 
   @@map("url_mappings")
 }

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/routes/admin.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/routes/admin.ts
@@ -19,8 +19,8 @@ function rowToDict_UrlMapping(r: Record<string, unknown>): Record<string, unknow
   return {
     code: r.code,
     url: r.url,
-    created_at: r.createdAt == null ? null : new Date(r.createdAt as string | Date).toISOString(),
-    click_count: r.clickCount,
+    created_at: r.created_at == null ? null : new Date(r.created_at as string | Date).toISOString(),
+    click_count: r.click_count,
   };
 }
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/schemas/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/schemas/urlMapping.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const UrlMappingCreateSchema = z.object({
   code: z.string().min(6).regex(/^(?:^[a-zA-Z0-9]+$)$/),
   url: z.string().min(1).regex(/^(?:^https?:\/\/[^\s\x00-\x1f\x7f]+)$/),
-  createdAt: z.coerce.date(),
-  clickCount: z.number(),
+  created_at: z.coerce.date(),
+  click_count: z.number(),
 });
 
 export type UrlMappingCreate = z.infer<typeof UrlMappingCreateSchema>;

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/types/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/types/urlMapping.ts
@@ -3,23 +3,23 @@ export interface UrlMapping {
   id: number;
   code: string;
   url: string;
-  createdAt: Date;
-  clickCount: number;
+  created_at: Date;
+  click_count: number;
 }
 
 export interface UrlMappingCreate {
   code: string;
   url: string;
-  createdAt: Date;
-  clickCount: number;
+  created_at: Date;
+  click_count: number;
 }
 
 export interface UrlMappingRead {
   id: number;
   code: string;
   url: string;
-  createdAt: Date;
-  clickCount: number;
+  created_at: Date;
+  click_count: number;
 }
 
 export interface ShortenRequest {

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/schema.prisma
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/schema.prisma
@@ -11,8 +11,8 @@ model UrlMapping {
   id BigInt @id @default(autoincrement())
   code String
   url String
-  createdAt DateTime @map("created_at")
-  clickCount Int @map("click_count")
+  created_at DateTime
+  click_count Int
 
   @@map("url_mappings")
 }

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/routes/admin.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/routes/admin.ts
@@ -19,8 +19,8 @@ function rowToDict_UrlMapping(r: Record<string, unknown>): Record<string, unknow
   return {
     code: r.code,
     url: r.url,
-    created_at: r.createdAt == null ? null : new Date(r.createdAt as string | Date).toISOString(),
-    click_count: r.clickCount,
+    created_at: r.created_at == null ? null : new Date(r.created_at as string | Date).toISOString(),
+    click_count: r.click_count,
   };
 }
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/schemas/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/schemas/urlMapping.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const UrlMappingCreateSchema = z.object({
   code: z.string().min(6).regex(/^(?:^[a-zA-Z0-9]+$)$/),
   url: z.string().min(1).regex(/^(?:^https?:\/\/[^\s\x00-\x1f\x7f]+)$/),
-  createdAt: z.coerce.date(),
-  clickCount: z.number(),
+  created_at: z.coerce.date(),
+  click_count: z.number(),
 });
 
 export type UrlMappingCreate = z.infer<typeof UrlMappingCreateSchema>;

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/types/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/types/urlMapping.ts
@@ -3,23 +3,23 @@ export interface UrlMapping {
   id: number;
   code: string;
   url: string;
-  createdAt: Date;
-  clickCount: number;
+  created_at: Date;
+  click_count: number;
 }
 
 export interface UrlMappingCreate {
   code: string;
   url: string;
-  createdAt: Date;
-  clickCount: number;
+  created_at: Date;
+  click_count: number;
 }
 
 export interface UrlMappingRead {
   id: number;
   code: string;
   url: string;
-  createdAt: Date;
-  clickCount: number;
+  created_at: Date;
+  click_count: number;
 }
 
 export interface ShortenRequest {

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/AdminRouterTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/AdminRouterTs.scala
@@ -26,7 +26,7 @@ object AdminRouterTs:
     def colsOf(e: entity_decl): List[Col] =
       entFields(e).map: f =>
         Col(
-          tsField = Naming.toCamelCase(fldName(f)),
+          tsField = fldName(f),
           columnName = Naming.toColumnName(fldName(f)),
           isDate = isDateTimeType(svcTypeAliases(ir), fldType(f))
         )
@@ -98,10 +98,10 @@ object AdminRouterTs:
                    |          (r: Record<string, unknown>) => rowToDict_${p.entityName}(r),
                    |        ),""".stripMargin
               case shape =>
-                val keyTs = Naming.toCamelCase(p.keyFieldName)
+                val keyTs = p.keyFieldName
                 val value = shape match
                   case AdminModel.ProjectionValue.PrimitiveField(name) =>
-                    s"r.${Naming.toCamelCase(name)}"
+                    s"r.$name"
                   case _ =>
                     s"rowToDict_${p.entityName}(r)"
                 s"""        ${tsKey(stfName(f))}: Object.fromEntries(
@@ -118,7 +118,7 @@ object AdminRouterTs:
       .map: e =>
         val snake = Naming.toSnakeCase(entName(e))
         val pk    = AdminModel.primaryKeyField(e).getOrElse("id")
-        val pkTs  = Naming.toCamelCase(pk)
+        val pkTs  = pk
         val cols  = colsOf(e)
         val dataPairs = cols
           .map: c =>

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -734,7 +734,7 @@ object EmitTs:
       reduced: StringRefinements.Reduced = StringRefinements.Reduced(None, None, Nil),
       enumValues: Option[List[String]] = None
   ): TsFieldView =
-    val tsName = toCamelCase(f.fieldName)
+    val tsName = f.fieldName
     val attrs  = prismaAttrs(f, tsName, nativeAttrs)
     // Enum-typed inputs validate as z.enum members at the boundary: the
     // kernel constructs the datatype by member name and must never see an
@@ -909,7 +909,7 @@ object EmitTs:
     val pathArgsCsv    = pathParams.map(_.tsName).mkString(", ")
 
     val lookupField =
-      toCamelCase(EmitShared.lookupColumn(entity, endpoint.pathParams.headOption.map(_.name)))
+      EmitShared.lookupColumn(entity, endpoint.pathParams.headOption.map(_.name))
 
     val createDataObj = nonIdFields
       .map(f => s"${f.tsField}: body.${f.tsField}")
@@ -965,7 +965,7 @@ object EmitTs:
           val sig = pathParams.map(p => s"${p.tsName}: ${p.domainType}").mkString(", ")
           (op.operationName, pathArgsCsv, sig, "Promise<boolean>", Option.empty[String], deleteCall)
         case _: RkRedirect =>
-          val tgt = EmitShared.redirectTargetColumn(entity).map(toCamelCase).getOrElse("url")
+          val tgt = EmitShared.redirectTargetColumn(entity).getOrElse("url")
           val sig = pathParams.map(p => s"${p.tsName}: ${p.domainType}").mkString(", ")
           (
             op.operationName,
@@ -1062,9 +1062,6 @@ object EmitTs:
   private def tsElemToDafny(el: String, ref: String): String =
     if el == "str" then s"stringToDafny($ref as string)" else s"intToDafny($ref as number)"
 
-  private def camelName(name: String): String =
-    Naming.toCamelCase(name, Naming.CamelStrategy.Ts)
-
   private def tsKernelServiceFn(
       op: ProfiledOperation,
       handlerName: String,
@@ -1120,7 +1117,7 @@ object EmitTs:
       val inputs =
         endpoint.pathParams.map(p => p.name -> toCamelCase(p.name)) ++
           endpoint.queryParams.map(p => p.name -> toCamelCase(p.name)) ++
-          endpoint.bodyParams.map(p => p.name -> s"body.${toCamelCase(p.name)}")
+          endpoint.bodyParams.map(p => p.name -> s"body.${p.name}")
       val convertedArgs = inputs.map: (specName, access) =>
         specInputTypes
           .get(specName)
@@ -1253,19 +1250,19 @@ object EmitTs:
             // The response nests the entity under the spec's output name.
             val outName = specOutputs.headOption.map(prmName).getOrElse("result")
             val pairs = entityOutputFields.map: f =>
-              s"      ${camelName(f.fieldName)}: ${StateBridgeTs
+              s"      ${f.fieldName}: ${StateBridgeTs
                   .fromDafnyExpr(kernelCtx.ir, outEntity.map(_.entityName).getOrElse(""), f, "out")},"
             (
               "Record<string, unknown>",
               (s"  const out = $call as Record<string, unknown>;" ::
                 "  const result = {" ::
-                s"    ${camelName(outName)}: {" :: pairs) :::
+                s"    ${outName}: {" :: pairs) :::
                 List("    },", "  };", "  return result;")
             )
           else if seqEntityOutput.isDefined then
             val entityName = seqEntityOutput.map(_.entityName).getOrElse("")
             val pairs = entityOutputFields.map: f =>
-              s"      ${camelName(f.fieldName)}: ${StateBridgeTs.fromDafnyExpr(kernelCtx.ir, entityName, f, "elem")},"
+              s"      ${f.fieldName}: ${StateBridgeTs.fromDafnyExpr(kernelCtx.ir, entityName, f, "elem")},"
             (
               "Array<Record<string, unknown>>",
               (s"  const out = $call;" ::
@@ -1285,10 +1282,10 @@ object EmitTs:
               case many =>
                 val vars = many.map(f => "out" + toPascalCase(f.fieldName))
                 val typeBody =
-                  many.map(f => s"${toCamelCase(f.fieldName)}: ${f.domainType}").mkString("; ")
+                  many.map(f => s"${f.fieldName}: ${f.domainType}").mkString("; ")
                 val unknowns = List.fill(vars.size)("unknown").mkString(", ")
                 val retFields =
-                  many.zip(vars).map((f, v) => s"${toCamelCase(f.fieldName)}: ${fromDafny(f, v)}")
+                  many.zip(vars).map((f, v) => s"${f.fieldName}: ${fromDafny(f, v)}")
                 (
                   s"{ $typeBody }",
                   List(

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
@@ -127,7 +127,7 @@ object StateBridgeTs:
       f: ProfiledField,
       rowRef: String
   ): String =
-    val access = s"$rowRef.${camel(f.fieldName)}"
+    val access = s"$rowRef.${f.fieldName}"
     kindFor(ir, entityName, f).map(specrest.codegen.KernelTypes.unwrapOpt) match
       case Some(Kind.EnumK(n)) if !f.nullable =>
         s"enumToDafny('$n', $access as string)"
@@ -209,8 +209,8 @@ object StateBridgeTs:
 
   private def keyToDafny(key: ProfiledField, rowRef: String): String =
     key.domainType match
-      case "string" => s"stringToDafny($rowRef.${camel(key.fieldName)})"
-      case _        => s"intToDafny($rowRef.${camel(key.fieldName)})"
+      case "string" => s"stringToDafny($rowRef.${key.fieldName})"
+      case _        => s"intToDafny($rowRef.${key.fieldName})"
 
   def emit(profiled: ProfiledService): String =
     val planned = plan(profiled) match
@@ -294,15 +294,15 @@ object StateBridgeTs:
     def accInsert(r: StatePlan.RelationPlan, key: ProfiledField, pad: String): List[String] =
       List(
         s"${pad}for (const r of ${relRowsVar(r)}) {",
-        s"$pad  ${relAcc(r)}.set(r.${camel(key.fieldName)}, r);",
+        s"$pad  ${relAcc(r)}.set(r.${key.fieldName}, r);",
         s"$pad}"
       )
     def stepLines(r: StatePlan.RelationPlan, key: ProfiledField, shape: StepShape): List[String] =
-      val rel      = r.stateField
-      val client   = camel(r.entity.entityName)
-      val sel      = relSel(r)
-      val rows     = relRowsVar(r)
-      val keyCamel = camel(key.fieldName)
+      val rel     = r.stateField
+      val client  = camel(r.entity.entityName)
+      val sel     = relSel(r)
+      val rows    = relRowsVar(r)
+      val keyName = key.fieldName
       def srcAccOf(src: String): String =
         relByField.get(src).map(relAcc).getOrElse(s"${camel(src)}Acc")
       shape match
@@ -317,19 +317,19 @@ object StateBridgeTs:
             s"  const $keysVar = $sel.flatMap((d) => (d.kind === 'keys' ? [...d.keys] : []));",
             s"  if ($keysVar.length > 0) {",
             s"    const $rows = await tx.$client.findMany({",
-            s"      where: { $keyCamel: { in: $keysVar as ${keysCast(key)} } },",
+            s"      where: { $keyName: { in: $keysVar as ${keysCast(key)} } },",
             "    });"
           ) ::: accInsert(r, key, "    ") ::: List("  }")
         case StepShape.FieldOf(src, field) =>
           val srcField = relByField.get(src).toList
             .flatMap(_.entity.fields)
             .find(_.fieldName == field)
-          val srcCamel = srcField.map(f => camel(f.fieldName)).getOrElse(camel(field))
-          val keysVar  = s"${camel(rel)}From${Naming.toPascalCase(src)}Keys"
-          val proj     = projFor(key, s"r.$srcCamel")
+          val srcName = srcField.map(_.fieldName).getOrElse(field)
+          val keysVar = s"${camel(rel)}From${Naming.toPascalCase(src)}Keys"
+          val proj    = projFor(key, s"r.$srcName")
           val gather =
             if srcField.exists(_.nullable) then
-              s"      ...new Set([...${srcAccOf(src)}.values()].flatMap((r) => (r.$srcCamel === null ? [] : [$proj]))),"
+              s"      ...new Set([...${srcAccOf(src)}.values()].flatMap((r) => (r.$srcName === null ? [] : [$proj]))),"
             else s"      ...new Set([...${srcAccOf(src)}.values()].map((r) => $proj)),"
           List(
             s"  if ($sel.some((d) => d.kind === 'fieldOf' && d.src === '$src' && d.field === '$field')) {",
@@ -338,12 +338,12 @@ object StateBridgeTs:
             s"    ]${sortFor(key)};",
             s"    if ($keysVar.length > 0) {",
             s"      const $rows = await tx.$client.findMany({",
-            s"        where: { $keyCamel: { in: $keysVar } },",
+            s"        where: { $keyName: { in: $keysVar } },",
             "      });"
           ) ::: accInsert(r, key, "      ") ::: List("    }", "  }")
         case StepShape.ValueCol(src, column) =>
           val colField = r.entity.fields.find(_.fieldName == column)
-          val colCamel = colField.map(f => camel(f.fieldName)).getOrElse(camel(column))
+          val colName  = colField.map(_.fieldName).getOrElse(column)
           val srcKeys = colField match
             case Some(cf) if baseTs(cf.domainType) != "string" =>
               s"[...${srcAccOf(src)}.keys()].map((k) => Number(k)).sort($numCmp)"
@@ -354,13 +354,13 @@ object StateBridgeTs:
             s"    ${srcAccOf(src)}.size > 0",
             "  ) {",
             s"    const $rows = await tx.$client.findMany({",
-            s"      where: { $colCamel: { in: $srcKeys } },",
+            s"      where: { $colName: { in: $srcKeys } },",
             "    });"
           ) ::: accInsert(r, key, "    ") ::: List("  }")
         case StepShape.Dependent(src, coll, elem) =>
           val srcEntity = relByField.get(src).map(_.entity)
           val collField = srcEntity.toList.flatMap(_.fields).find(_.fieldName == coll)
-          val collCamel = collField.map(f => camel(f.fieldName)).getOrElse(camel(coll))
+          val collName  = collField.map(_.fieldName).getOrElse(coll)
           val nested = collField
             .flatMap(f => srcEntity.flatMap(e => kindFor(profiled.ir, e.entityName, f)))
             .collect { case Kind.EntitySetOf(en) => en }
@@ -368,7 +368,7 @@ object StateBridgeTs:
           nested.toList.flatMap { ne =>
             val neCamel   = camel(ne.entityName)
             val elemField = ne.fields.find(_.fieldName == elem)
-            val elemCamel = elemField.map(f => camel(f.fieldName)).getOrElse(camel(elem))
+            val elemName  = elemField.map(_.fieldName).getOrElse(elem)
             val keysVar   = s"${camel(rel)}DepKeys"
             List(
               "  if (",
@@ -379,16 +379,16 @@ object StateBridgeTs:
               s"    const $keysVar = [",
               "      ...new Set(",
               s"        [...${srcAccOf(src)}.values()].flatMap((r) =>",
-              s"          (r.$collCamel as number[]).flatMap((x) => {",
+              s"          (r.$collName as number[]).flatMap((x) => {",
               s"            const li = ${neCamel}ById.get(Number(x));",
-              s"            return li ? [${projFor(key, s"li.$elemCamel")}] : [];",
+              s"            return li ? [${projFor(key, s"li.$elemName")}] : [];",
               "          }),",
               "        ),",
               "      ),",
               s"    ]${sortFor(key)};",
               s"    if ($keysVar.length > 0) {",
               s"      const $rows = await tx.$client.findMany({",
-              s"        where: { $keyCamel: { in: $keysVar } },",
+              s"        where: { $keyName: { in: $keysVar } },",
               "      });"
             ) ::: accInsert(r, key, "      ") ::: List("    }", "  }")
           }
@@ -453,7 +453,7 @@ object StateBridgeTs:
     for (r, key) <- keyedRelations do
       val model = r.entity.modelClassName
       hydrate ++= s"  const ${relSel(r)} = sc.${r.stateField} ?? [];\n"
-      hydrate ++= s"  const ${relAcc(r)} = new Map<$model['${camel(key.fieldName)}'], $model>();\n"
+      hydrate ++= s"  const ${relAcc(r)} = new Map<$model['${key.fieldName}'], $model>();\n"
     for ne <- nestedEntities do
       hydrate ++= s"  const ${camel(ne.entityName)}Ids = new Set<number>();\n"
     // Seq-valued state loads whole or not at all (a seq present in scope is
@@ -475,7 +475,7 @@ object StateBridgeTs:
           hydrate,
           List(
             s"  for (const r of ${relRowsVar(r)}) {",
-            s"    for (const x of r.${camel(f.fieldName)} as number[]) {",
+            s"    for (const x of r.${f.fieldName} as number[]) {",
             s"      ${camel(ne.entityName)}Ids.add(Number(x));",
             "    }",
             "  }"
@@ -514,7 +514,7 @@ object StateBridgeTs:
             hydrate,
             List(
               s"  for (const r of ${relAcc(r)}.values()) {",
-              s"    for (const x of r.${camel(f.fieldName)} as number[]) {",
+              s"    for (const x of r.${f.fieldName} as number[]) {",
               s"      ${camel(ne.entityName)}Ids.add(Number(x));",
               "    }",
               "  }"
@@ -547,7 +547,7 @@ object StateBridgeTs:
         persist ++= s"    const ${client}Olds = await tx.$client.findMany();\n"
         for (f, ne) <- seqNested do
           persist ++= s"    for (const r of ${client}Olds) {\n"
-          persist ++= s"      for (const x of r.${camel(f.fieldName)} as number[]) {\n"
+          persist ++= s"      for (const x of r.${f.fieldName} as number[]) {\n"
           persist ++= s"        ${camel(ne.entityName)}PreIds.add(Number(x));\n"
           persist ++= "      }\n"
           persist ++= "    }\n"
@@ -558,7 +558,7 @@ object StateBridgeTs:
       persist ++= "      const value = v as Record<string, unknown>;\n"
       persist ++= s"      await tx.$client.create({\n        data: {\n"
       for f <- e.fields do
-        persist ++= s"          ${camel(f.fieldName)}: ${fromDafnyExpr(profiled.ir, e.entityName, f, "value")},\n"
+        persist ++= s"          ${f.fieldName}: ${fromDafnyExpr(profiled.ir, e.entityName, f, "value")},\n"
       persist ++= "        },\n      });\n"
       persist ++= "    }\n"
       persist ++= "  }\n"
@@ -580,7 +580,7 @@ object StateBridgeTs:
       persist ++= s"        ? await tx.$client.findMany({\n"
       persist ++= "            where:\n"
       persist ++= s"              $sel.kind === 'keys'\n"
-      persist ++= s"                ? { ${camel(rKey.fieldName)}: { in: ${sortedHydratedKeys(sel, rKey)} } }\n"
+      persist ++= s"                ? { ${rKey.fieldName}: { in: ${sortedHydratedKeys(sel, rKey)} } }\n"
       persist ++= "                : undefined,\n"
       persist ++= "          })\n"
       persist ++= "        : [];\n"
@@ -588,13 +588,13 @@ object StateBridgeTs:
       // arrive as bigint and dafny keys convert through number, so comparing
       // their canonical string forms avoids both bigint mismatch and float
       // precision loss on large ids.
-      persist ++= s"    const ${client}Existing = new Map(${client}Rows.map((r) => [String(r.${camel(rKey.fieldName)}), r]));\n"
+      persist ++= s"    const ${client}Existing = new Map(${client}Rows.map((r) => [String(r.${rKey.fieldName}), r]));\n"
       // Nested ids collect before the upsert loop mutates these rows: the
       // nested delete scan may only judge rows the hydrated owners referenced
       // in their pre state.
       for (f, ne) <- nestedFieldsOf(e) do
         persist ++= s"    for (const r of ${client}Rows) {\n"
-        persist ++= s"      for (const x of r.${camel(f.fieldName)} as number[]) {\n"
+        persist ++= s"      for (const x of r.${f.fieldName} as number[]) {\n"
         persist ++= s"        ${camel(ne.entityName)}PreIds.add(Number(x));\n"
         persist ++= "      }\n"
         persist ++= "    }\n"
@@ -608,14 +608,14 @@ object StateBridgeTs:
       val nonKey = e.fields.filter(_.fieldName != rKey.fieldName)
       persist ++= "      const data = {\n"
       for f <- nonKey do
-        persist ++= s"        ${camel(f.fieldName)}: ${fromDafnyExpr(profiled.ir, e.entityName, f, "value")},\n"
+        persist ++= s"        ${f.fieldName}: ${fromDafnyExpr(profiled.ir, e.entityName, f, "value")},\n"
       persist ++= "      };\n"
       persist ++= s"      const row = ${client}Existing.get(key);\n"
       persist ++= "      if (row) {\n"
       persist ++= s"        await tx.$client.update({ where: { id: row.id }, data });\n"
       persist ++= "      } else {\n"
       persist ++= s"        await tx.$client.create({\n"
-      persist ++= s"          data: { ${camel(rKey.fieldName)}: ${fromDafnyExpr(profiled.ir, e.entityName, rKey, "value")}, ...data },\n"
+      persist ++= s"          data: { ${rKey.fieldName}: ${fromDafnyExpr(profiled.ir, e.entityName, rKey, "value")}, ...data },\n"
       persist ++= "        });\n"
       persist ++= "      }\n"
       persist ++= "    }\n"
@@ -656,7 +656,7 @@ object StateBridgeTs:
       persist ++= s"  for (const [key, value] of ${client}Post) {\n"
       persist ++= "    const data = {\n"
       for f <- ne.fields if f.fieldName != "id" do
-        persist ++= s"      ${camel(f.fieldName)}: ${fromDafnyExpr(profiled.ir, ne.entityName, f, "value")},\n"
+        persist ++= s"      ${f.fieldName}: ${fromDafnyExpr(profiled.ir, ne.entityName, f, "value")},\n"
       persist ++= "    };\n"
       persist ++= s"    const row = ${client}Existing.get(key);\n"
       persist ++= "    if (row) {\n"

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -199,7 +199,7 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       val schema = files("prisma/schema.prisma")
       assert(!schema.contains("? ?"), schema)
       assert(schema.contains("description String? @db.Text"), schema)
-      assert(schema.contains("""completedAt DateTime? @map("completed_at")"""), schema)
+      assert(schema.contains("completed_at DateTime?"), schema)
 
   // chi.URLParam returns a string; an integer PK path param must be parsed via strconv
   // before the service call. A string-keyed entity must NOT import strconv (unused import

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -403,9 +403,9 @@ class EmitTest extends CatsEffectSuite:
       )
       assert(
         service.contains(
-          "return { code: stringFromDafny(outCode), shortUrl: stringFromDafny(outShortUrl) };"
+          "return { code: stringFromDafny(outCode), short_url: stringFromDafny(outShortUrl) };"
         ),
-        s"Shorten should marshal both outputs into a camelCase result object - got:\n$service"
+        s"Shorten should marshal both outputs into a snake_case result object - got:\n$service"
       )
       // Resolve: single scalar in/out.
       assert(

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTsTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTsTest.scala
@@ -85,7 +85,9 @@ class EmitTsTest extends CatsEffectSuite:
       val schema = files("prisma/schema.prisma")
       assert(schema.contains("model UrlMapping"), schema)
       assert(schema.contains("@@map(\"url_mappings\")"), schema)
-      assert(schema.contains("@map(\"created_at\")"), schema)
+      // Entity fields are snake in Prisma and match their column, so no field-level @map.
+      assert(schema.contains("created_at DateTime"), schema)
+      assert(!schema.contains("@map(\"created_at\")"), schema)
 
       val routes = files("src/routes/urlMappings.ts")
       assert(routes.contains("registerUrlMappingRoutes"), routes)

--- a/modules/testgen/src/main/resources/testgen-templates/typescript/express/tests/_runtime.ts
+++ b/modules/testgen/src/main/resources/testgen-templates/typescript/express/tests/_runtime.ts
@@ -52,20 +52,15 @@ export function _len(x: Anything): number {
   return 0;
 }
 
-// The ts API speaks camelCase while /admin/state serves spec-named (snake)
-// keys; the oracle normalizes the snapshot so both sides compare in one
-// casing. Only NAME keys camelize: state fields at the top level and entity
-// fields below. Relation keys one level under a state field are data (emails,
-// tokens, digit ids) and must pass through untouched.
-const camelKey = (k: string): string =>
-  k.replace(/_([a-z0-9])/g, (_m, c: string) => c.toUpperCase());
-
+// The ts API and /admin/state both serve spec-named (snake) keys, so the
+// snapshot keeps keys as-is and only normalizes structure: arrays and objects
+// recurse, primitives pass through.
 function snapshotDeep(v: Anything): Anything {
   if (Array.isArray(v)) return v.map(snapshotDeep);
   if (v !== null && typeof v === 'object') {
     const out: Record<string, Anything> = {};
     for (const [k, val] of Object.entries(v as Record<string, Anything>)) {
-      out[camelKey(k)] = snapshotDeep(val);
+      out[k] = snapshotDeep(val);
     }
     return out;
   }
@@ -81,9 +76,9 @@ export function stateSnapshot(v: Anything): Anything {
       for (const [key, row] of Object.entries(val as Record<string, Anything>)) {
         rel[key] = snapshotDeep(row);
       }
-      out[camelKey(field)] = rel;
+      out[field] = rel;
     } else {
-      out[camelKey(field)] = snapshotDeep(val);
+      out[field] = snapshotDeep(val);
     }
   }
   return out;

--- a/modules/testgen/src/main/scala/specrest/testgen/NativeSuites.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/NativeSuites.scala
@@ -278,12 +278,10 @@ private[testgen] object TsRender:
     val bodyExpr =
       if ep.bodyParams.isEmpty then ""
       else
-        // Request schemas key bodies in camelCase; query strings keep the
-        // spec's names (the routes read req.query by spec name).
+        // Request bodies key by the spec's field names (snake), matching the
+        // service's snake_case wire; query strings do the same.
         val pairs = ep.bodyParams
-          .map(p =>
-            s"${TsLit.str(specrest.ir.Naming.toCamelCase(p.name, specrest.ir.Naming.CamelStrategy.Plain))}: ${ref(p.name)}"
-          )
+          .map(p => s"${TsLit.str(p.name)}: ${ref(p.name)}")
           .mkString(", ")
         s", { $pairs }"
     s"client.$method($target$bodyExpr)"

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -1,7 +1,6 @@
 package specrest.testgen
 
 import specrest.ir.Builtins
-import specrest.ir.Naming
 import specrest.ir.generated.SpecRestGenerated.*
 
 private[testgen] val TsReservedNames: Set[String] = Set(
@@ -73,10 +72,10 @@ object TsExprBackend extends ExprBackendBase:
     case CaptureMode.PostState => "postState"
     case CaptureMode.PreState  => "preState"
 
-  // The ts surface is camelCase end to end: responses by convention, the
-  // state snapshot by normalization in stateSnapshot().
+  // The ts surface is snake_case end to end: request bodies, responses, and
+  // the /admin/state snapshot all key by the spec's field names.
   def containerAccess(container: String, name: String): String =
-    s"$container[${TsLit.str(Naming.toCamelCase(name, Naming.CamelStrategy.Plain))}]"
+    s"$container[${TsLit.str(name)}]"
 
   def indexAccess(base: String, idx: String): String = s"$base[$idx]"
 


### PR DESCRIPTION
The TypeScript target camelCased its request and response body fields (`customerId`), while go and python kept the spec's snake_case names (`customer_id`) and the shared OpenAPI documented snake. Two problems followed: a request body written for one target failed on ts, and ts's own generated `openapi.yaml` disagreed with the service it described.

go already models the intended split. Its Go struct fields are camelCase, but the JSON tags carry the spec's snake names, so the wire follows the spec while internal identifiers stay idiomatic. Even inside ts, the scalar service-state endpoint already emitted snake keys; only entity CRUD bodies had drifted to camel.

## The change

ts entity request and response body keys, and Prisma model field names, now use the spec field name. Internal identifiers stay camelCase: Prisma model delegates (`prisma.order`), handler functions, path-param variables, and the state-bridge locals. Because a Prisma entity field and its column now match, the field-level `@map` drops out. Path params stay positional and query params were already snake, so neither changes.

The conformance test emitter flips in lockstep. Generated request bodies and `/admin/state` reads key by snake names, and the test runtime stops normalizing the snapshot casing since both sides are snake now.

## Validation

The shared OpenAPI builder is untouched, so its golden staying unchanged is the proof that the wire now matches the contract. Full sbt suite green. The generated ecommerce ts service typechecks against its snake Prisma client (`tsc --noEmit` clean), a snake-body request returns 201 where it returned 422 before, a camelCase body is correctly rejected with 422, and conformance passes 24 of 24 (the one skip is the placeholder health test). url_shortener is the only spec with committed ts goldens; its fields are single-word, so the flip leaves them unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the TypeScript codegen JSON wire to snake_case for entity request/response bodies and Prisma fields, matching the OpenAPI spec and other targets. This fixes cross-target incompatibility and makes generated TS services consistent with their `openapi.yaml`.

- **Bug Fixes**
  - Use spec field names for entity body keys and Prisma model fields; internal identifiers stay camelCase.
  - Stop camelizing body keys in codegen; update admin router, state bridge, and redirect targets to read/write snake keys.
  - Remove Prisma `@map` on entity fields now that field and column names match.
  - Testgen and runtime updated: generated requests and `/admin/state` read/write snake keys; casing normalization removed.
  - OpenAPI builder unchanged; TS wire now matches the contract.

- **Migration**
  - Regenerate TS services.
  - Update clients to send and expect snake_case body keys; camelCase bodies now return 422.
  - No changes to path or query params.

<sup>Written for commit c6a6ccff042e3ac785cf638fee4ae9afbcc6241a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated TypeScript and Prisma outputs now use snake_case field names consistently across URL mapping data, request/response shapes, and admin state responses.

* **Bug Fixes**
  * Fixed mismatches between stored fields and generated code so timestamp and click-count values are read and written with the correct names.
  * Snapshot and assertion logic now preserves original field casing, improving test reliability for generated output.

* **Tests**
  * Updated code generation tests to match the new snake_case conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->