### PR TITLE
build(deps): patch jackson-databind and bump generated vitest to 3.2.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,12 +78,14 @@ val declineVersion          = "2.6.2"
 val apispecVersion          = "0.11.3"
 val snakeYamlVersion        = "2.3"
 val catsEffectVersion       = "3.7.0"
-val jacksonCoreVersion      = "2.18.6"
+val jacksonVersion          = "2.18.8"
 val anthropicJavaVersion    = "2.30.0"
 val openaiJavaVersion       = "4.35.0"
 
-// Scala 3.6.3's scaladoc toolchain still resolves jackson-core 2.15.1.
-ThisBuild / dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % jacksonCoreVersion
+// Scala 3.6.3's scaladoc toolchain still resolves jackson-core 2.15.1, and
+// jackson-databind is pulled in transitively below the advisory-patched 2.18.8.
+ThisBuild / dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core"     % jacksonVersion
+ThisBuild / dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
 
 lazy val commonMainDeps = Seq(
   "org.typelevel" %% "cats-effect" % catsEffectVersion

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/package.json
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^22.10.1",
     "@types/express": "^4.17.21",
     "prisma": "^6.2.0",
-    "vitest": "^2.1.8",
+    "vitest": "^3.2.6",
     "supertest": "^7.0.0",
     "@types/supertest": "^6.0.2",
     "tsx": "^4.19.2"

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/package.json
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^22.10.1",
     "@types/express": "^4.17.21",
     "prisma": "^6.2.0",
-    "vitest": "^2.1.8",
+    "vitest": "^3.2.6",
     "supertest": "^7.0.0",
     "@types/supertest": "^6.0.2",
     "tsx": "^4.19.2"

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/package.json
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^22.10.1",
     "@types/express": "^4.17.21",
     "prisma": "^6.2.0",
-    "vitest": "^2.1.8",
+    "vitest": "^3.2.6",
     "supertest": "^7.0.0",
     "@types/supertest": "^6.0.2",
     "tsx": "^4.19.2"

--- a/modules/profile/src/main/scala/specrest/profile/Targets.scala
+++ b/modules/profile/src/main/scala/specrest/profile/Targets.scala
@@ -227,7 +227,7 @@ object Express extends Framework:
         DependencySpec("@types/node", "^22.10.1"),
         DependencySpec("@types/express", "^4.17.21"),
         DependencySpec("prisma", "^6.2.0"),
-        DependencySpec("vitest", "^2.1.8"),
+        DependencySpec("vitest", "^3.2.6"),
         DependencySpec("supertest", "^7.0.0"),
         DependencySpec("@types/supertest", "^6.0.2"),
         DependencySpec("tsx", "^4.19.2")


### PR DESCRIPTION
Clears two of the open dependency advisories, each addressed where it actually applies, and explains why the third is left alone.

## jackson-databind 2.18.8 (2 high)

jackson-databind comes in transitively (through the anthropic-java and openai-java SDKs) at a version below 2.18.8, which is where the array subtype allowlist bypass and the PolymorphicTypeValidator bypass are patched. build.sbt already pinned jackson-core with a dependencyOverride; this adds a matching override for jackson-databind and lifts both to 2.18.8. No generated output changes; the whole sbt suite stays green.

## vitest 3.2.6 (3 critical)

vitest is a devDependency of the generated TypeScript projects, so every generated project shipped a vitest below 3.2.6 with an open advisory. `Targets.scala` now pins `^3.2.6`, and the three url_shortener ts goldens move to match.

vitest 2 to 3 is a major bump, so I validated it at runtime rather than trusting the version string. A freshly generated ecommerce ts service installs vitest 3.2.7, and its conformance suite runs to the identical profile it had under vitest 2: 24 passed, 0 failed, 1 skipped, no config or default-behavior breakage, no deprecation warnings. The generated `vitest.config.ts` is read and honored under v3. Clean drop-in.

## handlebars 4.5.2 (1 high) is intentionally not bumped

The advisory is a FileTemplateLoader path traversal, which only applies when templates are loaded from untrusted file paths. This codegen loads its templates as bundled classpath resources, so the vulnerable path is never reached. Bumping anyway is not free: handlebars 4.5.x changed its standalone-tag whitespace stripping, so the rendered output gains blank lines (for example between a service construction and its `return`), which would move every python, go, and ts golden. Churning the entire generated surface for an advisory that does not apply is the wrong trade, so this one stays at 4.3.1.

## Validation

Full sbt suite green across all modules. codegen goldens green (403). ecommerce ts conformance under vitest 3.2.7: 24 pass / 0 fail / 1 skip.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch security advisories by pinning `jackson-core`/`jackson-databind` to 2.18.8 and updating generated projects to `vitest` ^3.2.6. Leave `handlebars` as-is since the advisory doesn’t apply to our usage.

- **Dependencies**
  - Override `com.fasterxml.jackson.core:jackson-core` and `jackson-databind` to 2.18.8 to fix allowlist/validator bypasses; these arrive transitively via `anthropic-java` and `openai-java`.
  - Pin generated TypeScript projects to `vitest` `^3.2.6` via `Targets.scala` and update url_shortener goldens.
  - Do not bump `handlebars` (stay at 4.3.1); the `FileTemplateLoader` path traversal doesn’t apply to classpath-loaded templates, and 4.5.x changes whitespace in generated files.

- **Validation**
  - All sbt modules green; codegen goldens green (403).
  - Generated TS service under `vitest` 3 runs unchanged: 24 pass / 0 fail / 1 skip; config is honored.

<sup>Written for commit 847d6b02df535863320de6b56f01f6e83c41736e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a set of dependency versions to keep the project aligned with the latest supported releases.
  * Refreshed test tooling across multiple templates and profiles for better compatibility and consistency.
  * Improved dependency override handling to ensure the correct security-patched library versions are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->