### PR TITLE
refactor(cli): fold shared spec-loading and Dafny-header scaffolding

### DIFF
--- a/modules/cli/src/main/scala/specrest/cli/Check.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Check.scala
@@ -67,6 +67,34 @@ object Check:
           )
         }
 
+  private[cli] def withParsedIR(specFile: String, log: Logger)(
+      k: ServiceIRFull => IO[ExitStatus]
+  ): IO[ExitStatus] =
+    readSource(specFile, log).flatMap:
+      case Left(code) => IO.pure(code)
+      case Right(source) =>
+        Parse.parseSpec(source).flatMap:
+          case Left(VerifyError.Parse(errors)) =>
+            IO.delay {
+              errors.foreach: e =>
+                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            }.as(ExitStatus.Violations)
+          case Right(parsed) =>
+            Builder.buildIR(parsed.tree).flatMap:
+              case Left(err) =>
+                IO.delay(log.error(renderBuildError(specFile, err))).as(ExitStatus.Violations)
+              case Right(ir) => k(ir)
+
+  private[cli] def testDowngradeNotice(target: String, downgrade: Boolean, log: Logger): IO[Unit] =
+    if downgrade then
+      IO.delay(
+        log.warn(
+          s"target $target does not support native test generation; skipping " +
+            "(pass --no-tests to silence this warning)"
+        )
+      )
+    else IO.unit
+
   private[cli] def renderConv(specFile: String, d: ConventionDiagnostic): String =
     val loc =
       d.span.collect { case SpanT(line, col, _, _) =>

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -12,7 +12,6 @@ import specrest.codegen.migration.SchemaDiff
 import specrest.convention.Classify
 import specrest.convention.Validate
 import specrest.dafny.Generator as DafnyGenerator
-import specrest.ir.VerifyError
 import specrest.ir.generated.SpecRestGenerated.LlmSynthesis
 import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
 import specrest.ir.generated.SpecRestGenerated.classificationOperationName
@@ -20,8 +19,6 @@ import specrest.ir.generated.SpecRestGenerated.classificationStrategy
 import specrest.ir.generated.SpecRestGenerated.migration_op
 import specrest.ir.generated.SpecRestGenerated.operation_classification
 import specrest.ir.generated.SpecRestGenerated.synthesis_strategy
-import specrest.parser.Builder
-import specrest.parser.Parse
 import specrest.profile.Annotate
 import specrest.profile.LanguageId
 import specrest.profile.ProfiledService
@@ -67,17 +64,9 @@ object Compile:
     case _               => false
 
   def run(specFile: String, opts: CompileOptions, log: Logger): IO[ExitStatus] =
-    val downgrade    = opts.withTests && !SupportedTargets.supports(opts.target)
-    val resolvedOpts = if downgrade then opts.copy(withTests = false) else opts
-    val downgradeNotice =
-      if downgrade then
-        IO.delay(
-          log.warn(
-            s"target ${opts.target} does not support native test generation; skipping " +
-              "(pass --no-tests to silence this warning)"
-          )
-        )
-      else IO.unit
+    val downgrade       = opts.withTests && !SupportedTargets.supports(opts.target)
+    val resolvedOpts    = if downgrade then opts.copy(withTests = false) else opts
+    val downgradeNotice = Check.testDowngradeNotice(opts.target, downgrade, log)
     val warnIfStrictWithoutTests =
       if resolvedOpts.strictStrategies && !resolvedOpts.withTests then
         IO.delay(
@@ -89,56 +78,43 @@ object Compile:
     downgradeNotice *> warnIfStrictWithoutTests *> runImpl(specFile, resolvedOpts, log)
 
   private def runImpl(specFile: String, opts: CompileOptions, log: Logger): IO[ExitStatus] =
-    Check.readSource(specFile, log).flatMap:
-      case Left(code) => IO.pure(code)
-      case Right(source) =>
-        Parse.parseSpec(source).flatMap:
-          case Left(VerifyError.Parse(errors)) =>
-            IO.delay {
-              errors.foreach: e =>
-                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            }.as(ExitStatus.Violations)
-          case Right(parsed) =>
-            Builder.buildIR(parsed.tree).flatMap:
-              case Left(err) =>
-                IO.delay(log.error(Check.renderBuildError(specFile, err))).as(ExitStatus.Violations)
-              case Right(ir) =>
-                val routeDiags = Validate.validateRoutes(ir) ++ Validate.validateSecurity(ir)
-                val gate =
-                  if routeDiags.nonEmpty then
-                    IO.delay(routeDiags.foreach(d => log.error(Check.renderConv(specFile, d))))
-                      .as(ExitStatus.Violations)
-                  else if opts.ignoreVerify then
-                    IO.delay(log.warn("proceeding without verification (--ignore-verify)"))
-                      .as(ExitStatus.Ok)
-                  else Verify.runGate(specFile, ir, VerificationConfig.Default, log)
-                gate.flatMap:
-                  case ok if ok == ExitStatus.Ok =>
-                    val strictGate =
-                      if opts.withTests && opts.strictStrategies then
-                        val unhandled = Strategies.forIR(ir).filter(_.skipped.nonEmpty)
-                        if unhandled.isEmpty then IO.pure(ExitStatus.Ok)
-                        else
-                          IO.delay {
-                            log.error(
-                              "--strict-strategies: type aliases / enums with incomplete strategy synthesis (no convention override registered):"
-                            )
-                            unhandled.foreach: s =>
-                              log.error(s"  ${s.typeName}: ${s.skipped.mkString("; ")}")
-                          }.as(ExitStatus.Violations)
-                      else IO.pure(ExitStatus.Ok)
+    Check.withParsedIR(specFile, log): ir =>
+      val routeDiags = Validate.validateRoutes(ir) ++ Validate.validateSecurity(ir)
+      val gate =
+        if routeDiags.nonEmpty then
+          IO.delay(routeDiags.foreach(d => log.error(Check.renderConv(specFile, d))))
+            .as(ExitStatus.Violations)
+        else if opts.ignoreVerify then
+          IO.delay(log.warn("proceeding without verification (--ignore-verify)"))
+            .as(ExitStatus.Ok)
+        else Verify.runGate(specFile, ir, VerificationConfig.Default, log)
+      gate.flatMap:
+        case ok if ok == ExitStatus.Ok =>
+          val strictGate =
+            if opts.withTests && opts.strictStrategies then
+              val unhandled = Strategies.forIR(ir).filter(_.skipped.nonEmpty)
+              if unhandled.isEmpty then IO.pure(ExitStatus.Ok)
+              else
+                IO.delay {
+                  log.error(
+                    "--strict-strategies: type aliases / enums with incomplete strategy synthesis (no convention override registered):"
+                  )
+                  unhandled.foreach: s =>
+                    log.error(s"  ${s.typeName}: ${s.skipped.mkString("; ")}")
+                }.as(ExitStatus.Violations)
+            else IO.pure(ExitStatus.Ok)
 
-                    strictGate.flatMap:
-                      case strictOk if strictOk == ExitStatus.Ok =>
-                        emitProject(specFile, ir, opts, log)
-                      case strictCode => IO.pure(strictCode)
-                  case gateCode =>
-                    IO.delay(
-                      log.error(
-                        s"$specFile: code generation blocked by the verification gate (exit ${gateCode.code}); " +
-                          "re-run with --ignore-verify to generate without verifying"
-                      )
-                    ).as(gateCode)
+          strictGate.flatMap:
+            case strictOk if strictOk == ExitStatus.Ok =>
+              emitProject(specFile, ir, opts, log)
+            case strictCode => IO.pure(strictCode)
+        case gateCode =>
+          IO.delay(
+            log.error(
+              s"$specFile: code generation blocked by the verification gate (exit ${gateCode.code}); " +
+                "re-run with --ignore-verify to generate without verifying"
+            )
+          ).as(gateCode)
 
   private def emitProject(
       specFile: String,

--- a/modules/cli/src/main/scala/specrest/cli/Diff.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Diff.scala
@@ -5,9 +5,6 @@ import specrest.cli.ExitStatus.given
 import specrest.codegen.Emit
 import specrest.codegen.EmitOptions
 import specrest.codegen.migration.Revision
-import specrest.ir.VerifyError
-import specrest.parser.Builder
-import specrest.parser.Parse
 import specrest.profile.Annotate
 import specrest.testgen.SupportedTargets
 import specrest.testgen.TestEmit
@@ -27,69 +24,47 @@ final case class DiffOptions(
 object Diff:
 
   def run(specFile: String, opts: DiffOptions, log: Logger): IO[ExitStatus] =
-    val downgrade    = opts.withTests && !SupportedTargets.supports(opts.target)
-    val resolvedOpts = if downgrade then opts.copy(withTests = false) else opts
-    val downgradeNotice =
-      if downgrade then
-        IO.delay(
-          log.warn(
-            s"target ${opts.target} does not support native test generation; skipping " +
-              "(pass --no-tests to silence this warning)"
-          )
-        )
-      else IO.unit
+    val downgrade       = opts.withTests && !SupportedTargets.supports(opts.target)
+    val resolvedOpts    = if downgrade then opts.copy(withTests = false) else opts
+    val downgradeNotice = Check.testDowngradeNotice(opts.target, downgrade, log)
     downgradeNotice *> runImpl(specFile, resolvedOpts, log)
 
   private def runImpl(specFile: String, opts: DiffOptions, log: Logger): IO[ExitStatus] =
-    Check.readSource(specFile, log).flatMap:
-      case Left(code) => IO.pure(code)
-      case Right(source) =>
-        Parse.parseSpec(source).flatMap:
-          case Left(VerifyError.Parse(errors)) =>
-            IO.delay {
-              errors.foreach: e =>
-                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            }.as(ExitStatus.Violations)
-          case Right(parsed) =>
-            Builder.buildIR(parsed.tree).flatMap:
-              case Left(err) =>
-                IO.delay(log.error(Check.renderBuildError(specFile, err)))
-                  .as(ExitStatus.Violations)
-              case Right(ir) =>
-                val gate =
-                  if opts.ignoreVerify then IO.pure(ExitStatus.Ok)
-                  else Verify.runGate(specFile, ir, VerificationConfig.Default, log)
-                gate.flatMap:
-                  case ok if ok == ExitStatus.Ok =>
-                    IO.blocking {
-                      val profiled = Annotate.buildProfiledService(ir, opts.target)
-                      val outRoot  = Paths.get(opts.outDir)
-                      val emitOpts = EmitOptions(
-                        previousSnapshot = SnapshotIO.readSnapshot(outRoot, log),
-                        existingRevisions = Revision.discover(outRoot, opts.target)
-                      )
-                      val baseFiles = Emit.emitProject(profiled, emitOpts)
-                      val testFiles = if opts.withTests then TestEmit.emit(profiled) else Nil
-                      val files     = baseFiles ++ testFiles
-                      val plans = if Files.isDirectory(outRoot) then Plan.classify(files, outRoot)
-                      else files.map(f => FilePlan(FileAction.Create, f.path))
-                      val changes = plans.filter: p =>
-                        p.action == FileAction.Create || p.action == FileAction.Update
-                      if changes.isEmpty then
-                        log.success(s"no drift: ${plans.length} files match ${opts.outDir}")
-                        ExitStatus.Ok
-                      else
-                        log.data(Plan.render(changes, log.palette))
-                        val t = Plan.tally(plans)
-                        log.warn(
-                          s"${changes.length} file(s) would change " +
-                            s"(create=${t.create} update=${t.update}; ${t.unchanged} unchanged)"
-                        )
-                        ExitStatus.Violations
-                    }.handleErrorWith:
-                      case NonFatal(e) =>
-                        IO.delay(
-                          log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
-                        ).as(ExitStatus.Violations)
-                      case e => IO.raiseError(e)
-                  case gateCode => IO.pure(gateCode)
+    Check.withParsedIR(specFile, log): ir =>
+      val gate =
+        if opts.ignoreVerify then IO.pure(ExitStatus.Ok)
+        else Verify.runGate(specFile, ir, VerificationConfig.Default, log)
+      gate.flatMap:
+        case ok if ok == ExitStatus.Ok =>
+          IO.blocking {
+            val profiled = Annotate.buildProfiledService(ir, opts.target)
+            val outRoot  = Paths.get(opts.outDir)
+            val emitOpts = EmitOptions(
+              previousSnapshot = SnapshotIO.readSnapshot(outRoot, log),
+              existingRevisions = Revision.discover(outRoot, opts.target)
+            )
+            val baseFiles = Emit.emitProject(profiled, emitOpts)
+            val testFiles = if opts.withTests then TestEmit.emit(profiled) else Nil
+            val files     = baseFiles ++ testFiles
+            val plans = if Files.isDirectory(outRoot) then Plan.classify(files, outRoot)
+            else files.map(f => FilePlan(FileAction.Create, f.path))
+            val changes = plans.filter: p =>
+              p.action == FileAction.Create || p.action == FileAction.Update
+            if changes.isEmpty then
+              log.success(s"no drift: ${plans.length} files match ${opts.outDir}")
+              ExitStatus.Ok
+            else
+              log.data(Plan.render(changes, log.palette))
+              val t = Plan.tally(plans)
+              log.warn(
+                s"${changes.length} file(s) would change " +
+                  s"(create=${t.create} update=${t.update}; ${t.unchanged} unchanged)"
+              )
+              ExitStatus.Violations
+          }.handleErrorWith:
+            case NonFatal(e) =>
+              IO.delay(
+                log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
+              ).as(ExitStatus.Violations)
+            case e => IO.raiseError(e)
+        case gateCode => IO.pure(gateCode)

--- a/modules/cli/src/main/scala/specrest/cli/Inspect.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Inspect.scala
@@ -8,10 +8,7 @@ import specrest.convention.Classify
 import specrest.dafny.DafnyMethodHeader
 import specrest.dafny.Generator as DafnyGenerator
 import specrest.ir.Serialize.given
-import specrest.ir.VerifyError
 import specrest.ir.generated.SpecRestGenerated.*
-import specrest.parser.Builder
-import specrest.parser.Parse
 import specrest.synth.PromptBuilder
 
 import java.io.PrintStream
@@ -40,24 +37,11 @@ object Inspect:
       out: PrintStream = System.out,
       operation: Option[String] = None
   ): IO[ExitStatus] =
-    Check.readSource(specFile, log).flatMap:
-      case Left(code) => IO.pure(code)
-      case Right(source) =>
-        Parse.parseSpec(source).flatMap:
-          case Left(VerifyError.Parse(errors)) =>
-            IO.delay {
-              errors.foreach: e =>
-                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            }.as(ExitStatus.Violations)
-          case Right(parsed) =>
-            Builder.buildIR(parsed.tree).flatMap:
-              case Left(err) =>
-                IO.delay(log.error(Check.renderBuildError(specFile, err))).as(ExitStatus.Violations)
-              case Right(ir) =>
-                renderIR(ir, format, operation) match
-                  case Right(text) => IO.blocking(out.println(text)).as(ExitStatus.Ok)
-                  case Left(msg) =>
-                    IO.delay(log.error(s"$specFile: $msg")).as(ExitStatus.Translator)
+    Check.withParsedIR(specFile, log): ir =>
+      renderIR(ir, format, operation) match
+        case Right(text) => IO.blocking(out.println(text)).as(ExitStatus.Ok)
+        case Left(msg) =>
+          IO.delay(log.error(s"$specFile: $msg")).as(ExitStatus.Translator)
 
   private def renderIR(
       ir: ServiceIRFull,

--- a/modules/cli/src/main/scala/specrest/cli/Synth.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Synth.scala
@@ -7,10 +7,7 @@ import specrest.cli.ExitStatus.given
 import specrest.convention.Classify
 import specrest.dafny.DafnyMethodHeader
 import specrest.dafny.Generator as DafnyGenerator
-import specrest.ir.VerifyError
 import specrest.ir.generated.SpecRestGenerated.*
-import specrest.parser.Builder
-import specrest.parser.Parse
 import specrest.synth.Cache
 import specrest.synth.CacheEntry
 import specrest.synth.CegisBudget
@@ -102,22 +99,7 @@ object Synth:
       out: PrintStream = System.out,
       err: PrintStream = System.err
   ): IO[ExitStatus] =
-    Check.readSource(specFile, log).flatMap:
-      case Left(code) => IO.pure(code)
-      case Right(source) =>
-        Parse.parseSpec(source).flatMap:
-          case Left(VerifyError.Parse(errors)) =>
-            IO.delay {
-              errors.foreach: e =>
-                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            }.as(ExitStatus.Violations)
-          case Right(parsed) =>
-            Builder.buildIR(parsed.tree).flatMap:
-              case Left(buildErr) =>
-                IO.delay(log.error(Check.renderBuildError(specFile, buildErr)))
-                  .as(ExitStatus.Violations)
-              case Right(ir) =>
-                runWithIR(specFile, ir, opts, log, out, err)
+    Check.withParsedIR(specFile, log)(ir => runWithIR(specFile, ir, opts, log, out, err))
 
   private def isDirectEmit(s: synthesis_strategy): Boolean = s match
     case _: DirectEmit => true
@@ -127,25 +109,23 @@ object Synth:
     case _: LlmSynthesis => true
     case _               => false
 
-  private def runWithIR(
+  private def withDafnyHeader(
       specFile: String,
       ir: ServiceIRFull,
-      opts: SynthOptions,
+      operation: String,
       log: Logger,
-      out: PrintStream,
-      err: PrintStream
+      directEmitMsg: String
+  )(
+      k: (operation_classification, DafnyMethodHeader, String) => IO[ExitStatus]
   ): IO[ExitStatus] =
     val classifications = Classify.classifyOperations(ir)
-    classifications.find(c => classificationOperationName(c) == opts.operation) match
+    classifications.find(c => classificationOperationName(c) == operation) match
       case None =>
-        IO.delay(log.error(s"$specFile: operation '${opts.operation}' not found"))
+        IO.delay(log.error(s"$specFile: operation '$operation' not found"))
           .as(ExitStatus.Violations)
       case Some(c) if isDirectEmit(classificationStrategy(c)) =>
         IO.delay(
-          log.error(
-            s"$specFile: operation '${opts.operation}' is classified DIRECT_EMIT; " +
-              "no LLM synthesis required"
-          )
+          log.error(s"$specFile: operation '$operation' is classified DIRECT_EMIT; $directEmitMsg")
         ).as(ExitStatus.Violations)
       case Some(c) =>
         DafnyGenerator.generate(ir) match
@@ -158,8 +138,20 @@ object Synth:
               case None =>
                 IO.delay(log.error(s"$specFile: no Dafny header for '$opName'"))
                   .as(ExitStatus.Translator)
-              case Some(header) =>
-                executeSynth(specFile, c, header, dafny.text, opts, log, out, err)
+              case Some(header) => k(c, header, dafny.text)
+
+  private def runWithIR(
+      specFile: String,
+      ir: ServiceIRFull,
+      opts: SynthOptions,
+      log: Logger,
+      out: PrintStream,
+      err: PrintStream
+  ): IO[ExitStatus] =
+    withDafnyHeader(specFile, ir, opts.operation, log, "no LLM synthesis required")(
+      (c, header, text) =>
+        executeSynth(specFile, c, header, text, opts, log, out, err)
+    )
 
   private def executeSynth(
       specFile: String,
@@ -227,21 +219,7 @@ object Synth:
       log: Logger,
       out: PrintStream = System.out
   ): IO[ExitStatus] =
-    Check.readSource(specFile, log).flatMap:
-      case Left(code) => IO.pure(code)
-      case Right(source) =>
-        Parse.parseSpec(source).flatMap:
-          case Left(VerifyError.Parse(errors)) =>
-            IO.delay {
-              errors.foreach: e =>
-                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            }.as(ExitStatus.Violations)
-          case Right(parsed) =>
-            Builder.buildIR(parsed.tree).flatMap:
-              case Left(buildErr) =>
-                IO.delay(log.error(Check.renderBuildError(specFile, buildErr)))
-                  .as(ExitStatus.Violations)
-              case Right(ir) => runAcceptWithIR(specFile, ir, opts, log, out)
+    Check.withParsedIR(specFile, log)(ir => runAcceptWithIR(specFile, ir, opts, log, out))
 
   private def runAcceptWithIR(
       specFile: String,
@@ -250,31 +228,10 @@ object Synth:
       log: Logger,
       out: PrintStream
   ): IO[ExitStatus] =
-    val classifications = Classify.classifyOperations(ir)
-    classifications.find(c => classificationOperationName(c) == opts.operation) match
-      case None =>
-        IO.delay(log.error(s"$specFile: operation '${opts.operation}' not found"))
-          .as(ExitStatus.Violations)
-      case Some(c) if isDirectEmit(classificationStrategy(c)) =>
-        IO.delay(
-          log.error(
-            s"$specFile: operation '${opts.operation}' is classified DIRECT_EMIT; " +
-              "no synthesized body is used"
-          )
-        ).as(ExitStatus.Violations)
-      case Some(c) =>
-        DafnyGenerator.generate(ir) match
-          case Left(dErr) =>
-            IO.delay(log.error(s"$specFile: Dafny generation failed: ${dErr.message}"))
-              .as(ExitStatus.Translator)
-          case Right(dafny) =>
-            val opName = classificationOperationName(c)
-            dafny.methods.find(_.name == opName) match
-              case None =>
-                IO.delay(log.error(s"$specFile: no Dafny header for '$opName'"))
-                  .as(ExitStatus.Translator)
-              case Some(header) =>
-                acceptBody(specFile, opName, header, dafny.text, opts, log, out)
+    withDafnyHeader(specFile, ir, opts.operation, log, "no synthesized body is used")(
+      (c, header, text) =>
+        acceptBody(specFile, classificationOperationName(c), header, text, opts, log, out)
+    )
 
   // The same gate the CEGIS loop applies to an LLM candidate, applied to a
   // provided body: splice into the skeleton, verify with dafny once, and only
@@ -348,21 +305,7 @@ object Synth:
       out: PrintStream = System.out,
       err: PrintStream = System.err
   ): IO[ExitStatus] =
-    Check.readSource(specFile, log).flatMap:
-      case Left(code) => IO.pure(code)
-      case Right(source) =>
-        Parse.parseSpec(source).flatMap:
-          case Left(VerifyError.Parse(errors)) =>
-            IO.delay {
-              errors.foreach: e =>
-                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            }.as(ExitStatus.Violations)
-          case Right(parsed) =>
-            Builder.buildIR(parsed.tree).flatMap:
-              case Left(buildErr) =>
-                IO.delay(log.error(Check.renderBuildError(specFile, buildErr)))
-                  .as(ExitStatus.Violations)
-              case Right(ir) => runVerifyWithIR(specFile, ir, opts, log, out, err)
+    Check.withParsedIR(specFile, log)(ir => runVerifyWithIR(specFile, ir, opts, log, out, err))
 
   private def runVerifyWithIR(
       specFile: String,
@@ -372,31 +315,10 @@ object Synth:
       out: PrintStream,
       err: PrintStream
   ): IO[ExitStatus] =
-    val classifications = Classify.classifyOperations(ir)
-    classifications.find(c => classificationOperationName(c) == opts.operation) match
-      case None =>
-        IO.delay(log.error(s"$specFile: operation '${opts.operation}' not found"))
-          .as(ExitStatus.Violations)
-      case Some(c) if isDirectEmit(classificationStrategy(c)) =>
-        IO.delay(
-          log.error(
-            s"$specFile: operation '${opts.operation}' is classified DIRECT_EMIT; " +
-              "no LLM synthesis required"
-          )
-        ).as(ExitStatus.Violations)
-      case Some(c) =>
-        DafnyGenerator.generate(ir) match
-          case Left(dErr) =>
-            IO.delay(log.error(s"$specFile: Dafny generation failed: ${dErr.message}"))
-              .as(ExitStatus.Translator)
-          case Right(dafny) =>
-            val opName = classificationOperationName(c)
-            dafny.methods.find(_.name == opName) match
-              case None =>
-                IO.delay(log.error(s"$specFile: no Dafny header for '$opName'"))
-                  .as(ExitStatus.Translator)
-              case Some(header) =>
-                executeCegis(specFile, c, header, dafny.text, opts, log, out, err)
+    withDafnyHeader(specFile, ir, opts.operation, log, "no LLM synthesis required")(
+      (c, header, text) =>
+        executeCegis(specFile, c, header, text, opts, log, out, err)
+    )
 
   private def executeCegis(
       specFile: String,
@@ -550,21 +472,7 @@ object Synth:
       log: Logger,
       err: PrintStream = System.err
   ): IO[ExitStatus] =
-    Check.readSource(specFile, log).flatMap:
-      case Left(code) => IO.pure(code)
-      case Right(source) =>
-        Parse.parseSpec(source).flatMap:
-          case Left(VerifyError.Parse(errors)) =>
-            IO.delay {
-              errors.foreach: e =>
-                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            }.as(ExitStatus.Violations)
-          case Right(parsed) =>
-            Builder.buildIR(parsed.tree).flatMap:
-              case Left(buildErr) =>
-                IO.delay(log.error(Check.renderBuildError(specFile, buildErr)))
-                  .as(ExitStatus.Violations)
-              case Right(ir) => runVerifyAllWithIR(specFile, ir, opts, log, err)
+    Check.withParsedIR(specFile, log)(ir => runVerifyAllWithIR(specFile, ir, opts, log, err))
 
   private def runVerifyAllWithIR(
       specFile: String,


### PR DESCRIPTION
First of two steps toward a jscpd duplication gate. Running jscpd over the Scala main sources put the codebase at 0.91 percent duplication (min-tokens 100), just under a 1 percent gate, and the largest concentration was in the CLI layer. This clears it so the gate lands with real headroom instead of tripping on the next PR.

The clones were genuine, not token coincidence. Six CLI entrypoints (compile, diff, inspect, and synth's run, accept, verify, and verify-all paths) each opened with the identical readSource, parseSpec, then buildIR ladder, short-circuiting on the same three errors before doing their own work. `Check.withParsedIR` runs that ladder once and hands back the built IR.

Inside synth, `runWithIR`, `runAcceptWithIR`, and `runVerifyWithIR` shared the entire classify, generate-Dafny, find-header ladder, differing only in one DIRECT_EMIT message and the final call. A local `withDafnyHeader` folds it, with the message passed in. The compile and diff commands also shared the withTests-downgrade warning, now `Check.testDowngradeNotice`.

Behavior is unchanged by construction: same log messages, same exit codes (DIRECT_EMIT and not-found stay Violations, Dafny-generation and missing-header stay Translator). The 73 CLI tests assert those messages and codes and still pass. `Check.run` and `Verify.run` were left alone; they weave timing logs through the same ladder, so they are not byte-compatible with the plain combinator.

## Effect

jscpd (min-tokens 100) across the Scala main sources drops from 0.91 percent to 0.56 percent, 23 clones to 15, and no clone touches a cli file anymore. Net 129 lines removed. Full sbt suite green, scalafixAll clean.

The gate workflow itself (non-blocking verbose report plus a blocking 1 percent gate on Scala and a separate looser threshold for the Isabelle proofs) follows in a second PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated CLI spec-loading and Dafny-header scaffolding to cut repetition while keeping behavior identical. This reduces jscpd duplication and prepares for a duplication gate.

- **Refactors**
  - Added `Check.withParsedIR` to run read → parse → build once and pass the IR; used by `compile`, `diff`, `inspect`, and all `synth` paths.
  - Added local `withDafnyHeader` in `Synth` to share classify → generate Dafny → find header; DIRECT_EMIT message is parameterized.
  - Moved the with-tests downgrade warning to `Check.testDowngradeNotice` and reused in `compile` and `diff`.
  - Behavior unchanged; CLI tests still pass. jscpd drops 0.91% → 0.56% (min-tokens 100), with 129 lines removed.

<sup>Written for commit 55b8e98a095eaeccbda72fe68d7ce611085ad1d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of spec parsing and IR building errors across CLI commands, with clearer failure reporting.
  * Standardized downgrade warnings when native test generation isn’t available.
  * Fixed inspection, diffing, synthesis, and compilation flows to behave more consistently when input specs can’t be processed.

* **Refactor**
  * Simplified several CLI commands by sharing common processing steps, improving maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->