### PR TITLE
ci: jscpd duplication report and budget gates

### DIFF
--- a/.github/workflows/duplication.yml
+++ b/.github/workflows/duplication.yml
@@ -1,0 +1,84 @@
+name: Duplication
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: duplication-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # The runner's pre-installed Node runs jscpd; dropping setup-node avoids
+      # zizmor's cache-poisoning rule (same choice as deploy-fly.yml).
+      - name: Verify pre-installed Node
+        run: node --version
+
+      - name: Duplication report (Scala main + test)
+        run: |
+          npx --yes jscpd@5.0.12 modules \
+            --pattern "**/src/{main,test}/scala/**/*.scala" \
+            --ignore "**/generated/**" \
+            --min-tokens 50 --min-lines 5 \
+            --reporters console,html --output jscpd-report/scala || true
+
+      - name: Duplication report (Isabelle proofs)
+        run: |
+          npx --yes jscpd@5.0.12 proofs \
+            --pattern "**/*.thy" \
+            --min-tokens 50 --min-lines 5 \
+            --reporters console,html --output jscpd-report/thy || true
+
+      - name: Upload HTML reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: jscpd-report
+          path: jscpd-report/
+          if-no-files-found: warn
+
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify pre-installed Node
+        run: node --version
+
+      - name: Scala main duplication within 1 percent
+        run: |
+          npx --yes jscpd@5.0.12 modules \
+            --pattern "**/src/main/scala/**/*.scala" \
+            --ignore "**/generated/**" \
+            --min-tokens 100 --min-lines 5 \
+            --threshold 1 --reporters console
+
+      # Isabelle theories have no jscpd tokenizer, so .jscpd.json maps .thy onto the
+      # generic clike lexer. That is approximate, so the proof budget is looser than
+      # the Scala one and the verbose report above is where proof repetition is read.
+      - name: Isabelle proof duplication within 2 percent
+        run: |
+          npx --yes jscpd@5.0.12 proofs \
+            --pattern "**/*.thy" \
+            --min-tokens 100 --min-lines 5 \
+            --threshold 2 --reporters console
+
+      - name: Changed-code duplication within 1 percent
+        if: github.event_name == 'pull_request'
+        env:
+          DIFF_BASE: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/jscpd-diff-gate.mjs

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,5 @@
+{
+  "formatsExts": {
+    "clike": ["thy"]
+  }
+}

--- a/scripts/jscpd-diff-gate.mjs
+++ b/scripts/jscpd-diff-gate.mjs
@@ -1,0 +1,73 @@
+import { execSync } from "node:child_process";
+import { readFileSync, existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const base = process.env.DIFF_BASE ?? "origin/main";
+const threshold = Number.parseFloat(process.env.DIFF_THRESHOLD ?? "1");
+const minTokens = process.env.DIFF_MIN_TOKENS ?? "100";
+const jscpdVersion = process.env.JSCPD_VERSION ?? "5.0.12";
+
+const sh = (cmd) => execSync(cmd, { encoding: "utf8" });
+const isScalaMain = (f) =>
+  /^modules\/[^/]+\/src\/main\/scala\/.*\.scala$/.test(f) && !f.includes("/generated/");
+
+let changed;
+try {
+  changed = sh(`git diff --name-only ${base}...HEAD`)
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(isScalaMain)
+    .filter(existsSync);
+} catch (e) {
+  console.error(`could not diff against ${base}: ${e.message}`);
+  process.exit(1);
+}
+
+if (changed.length === 0) {
+  console.log(`no changed Scala main sources vs ${base}; changed-code duplication gate passes`);
+  process.exit(0);
+}
+
+// Scan the whole tree, not only the changed files: a clone between a file this PR
+// touched and one it did not is exactly the "copied existing code" case we want to
+// catch, and it is invisible if jscpd only sees the changed files.
+const out = mkdtempSync(join(tmpdir(), "jscpd-diff-"));
+sh(
+  `npx --yes jscpd@${jscpdVersion} . --pattern "modules/**/src/main/scala/**/*.scala" ` +
+    `--ignore "**/generated/**" --min-tokens ${minTokens} --min-lines 5 ` +
+    `--reporters json --output ${out} --silent`,
+);
+const report = JSON.parse(readFileSync(join(out, "jscpd-report.json"), "utf8"));
+
+const changedSet = new Set(changed);
+const dupLines = new Map();
+const mark = (inst) => {
+  if (!changedSet.has(inst.name)) return;
+  const set = dupLines.get(inst.name) ?? new Set();
+  for (let l = inst.start; l <= inst.end; l++) set.add(l);
+  dupLines.set(inst.name, set);
+};
+for (const d of report.duplicates ?? []) {
+  mark(d.firstFile);
+  mark(d.secondFile);
+}
+
+let changedTotal = 0;
+let changedDup = 0;
+for (const f of changed) {
+  changedTotal += readFileSync(f, "utf8").split("\n").length;
+  changedDup += dupLines.get(f)?.size ?? 0;
+}
+const pct = changedTotal === 0 ? 0 : (changedDup / changedTotal) * 100;
+
+console.log(
+  `changed Scala main: ${changed.length} files, ${changedDup}/${changedTotal} lines duplicated = ${pct.toFixed(2)}%`,
+);
+for (const [f, s] of dupLines) console.log(`  ${f}: ${s.size} duplicated lines`);
+
+if (pct > threshold) {
+  console.error(`FAIL: changed-code duplication ${pct.toFixed(2)}% exceeds ${threshold}%`);
+  process.exit(1);
+}
+console.log(`OK: changed-code duplication ${pct.toFixed(2)}% within ${threshold}%`);

--- a/scripts/jscpd-diff-gate.mjs
+++ b/scripts/jscpd-diff-gate.mjs
@@ -56,7 +56,8 @@ for (const d of report.duplicates ?? []) {
 let changedTotal = 0;
 let changedDup = 0;
 for (const f of changed) {
-  changedTotal += readFileSync(f, "utf8").split("\n").length;
+  const content = readFileSync(f, "utf8");
+  changedTotal += content === "" ? 0 : content.split("\n").length - (content.endsWith("\n") ? 1 : 0);
   changedDup += dupLines.get(f)?.size ?? 0;
 }
 const pct = changedTotal === 0 ? 0 : (changedDup / changedTotal) * 100;


### PR DESCRIPTION
The second of two steps. PR #531 pulled the CLI duplication out so the Scala main sources sit at 0.56 percent (jscpd, min-tokens 100); this adds the workflow that keeps them there and surfaces the rest.

## Report (non-blocking)

Runs jscpd verbose over the Scala main and test sources and over the Isabelle proofs at min-tokens 50, lists every clone in the job log, and uploads an HTML report as an artifact. It never fails, so it is a standing view of where duplication lives, including the by-design cross-target emitter parallelism and the proof-script repetition.

## Gate (blocking)

Three checks:

- Scala main within 1 percent (min-tokens 100). Currently 0.56, so a single feature PR has room, but a new medium clone that pushes the total over trips it.
- Isabelle proofs within 2 percent (min-tokens 100, currently 0.28). The budget is deliberately looser: `.thy` has no jscpd tokenizer, so `.jscpd.json` maps it onto the generic clike lexer, which is approximate, and proof duplication is often irreducible. The verbose report is where proof repetition is meant to be read; this gate is just a backstop against egregious growth.
- Changed-code within 1 percent, on pull requests only. `scripts/jscpd-diff-gate.mjs` scans the whole tree (so a clone between a file the PR touched and one it did not still counts, the copied-existing-code case) and fails if the duplication inside the PR's changed Scala files clears 1 percent.

## Parameters and validation

min-tokens 100 is the meaningful-block threshold; at 50 the noise dominates (2.5 percent), at 150 it misses medium clones (0.45 percent). Everything was checked locally: the Scala gate passes at 1 percent and fails at 0.1 percent, the proof gate passes at 2 percent, and the diff script was run against a synthetic file with a large self-clone, which it flagged at 85.71 percent and failed, and against a no-change base, which it passed. zizmor is clean on the workflow. jscpd is pinned to 5.0.12, and Node comes from the runner to satisfy zizmor's cache-poisoning rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI duplication workflow that reports code clones and enforces budgets for Scala and Isabelle sources. Blocks PRs that exceed thresholds and uploads an HTML report for visibility.

- **New Features**
  - Non-blocking report job runs `jscpd` (min-tokens 50) on Scala main+test and `.thy`, prints all clones, and uploads an HTML artifact.
  - Gates: Scala main ≤1% (min-tokens 100); Isabelle proofs ≤2% (min-tokens 100, `.thy` mapped to `clike` via `.jscpd.json`).
  - PR-only diff gate: `scripts/jscpd-diff-gate.mjs` scans the whole tree and measures duplication only inside changed Scala main files; fails if >1%.

- **Bug Fixes**
  - Diff gate counts changed lines correctly by excluding the trailing-newline phantom, preventing undercounting near the 1% threshold.

<sup>Written for commit c9ae460c1f8ee269b8abf39d46d43d6ee75f793b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

