### PR TITLE
refactor(codegen): share compose scaffolding and unify kernel-output marshalling

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/EmitShared.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/EmitShared.scala
@@ -247,8 +247,9 @@ private[codegen] object EmitShared:
 
   // Whether an operation's outputs can be marshaled from the kernel result: no output
   // is a plain effect call, an entity output needs every read-shape field marshalable,
-  // and a scalar output needs every field in the target's kernel-convertible set. That
-  // set is the only per-target input, since each language converts its own scalar types.
+  // and a scalar output needs every field non-nullable and in the target's kernel-convertible
+  // set. That set is the only per-target input, since each language converts its own scalars.
+  // Nullable scalar results defer (their rendered type is not a convertible key anyway).
   def kernelOutputsOk(
       shape: KernelOutputShape,
       specOutputs: List[param_decl],
@@ -261,4 +262,7 @@ private[codegen] object EmitShared:
         shape.outFieldKinds,
         _
       ))
-    else scalarOutputs.nonEmpty && scalarOutputs.forall(f => scalarConvTypes.contains(f.domainType))
+    else
+      scalarOutputs.nonEmpty && scalarOutputs.forall(f =>
+        !f.nullable && scalarConvTypes.contains(f.domainType)
+      )

--- a/modules/codegen/src/main/scala/specrest/codegen/EmitShared.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/EmitShared.scala
@@ -172,3 +172,17 @@ private[codegen] object EmitShared:
     firstPathParam match
       case Some(p) if entity.fields.exists(_.columnName == p) => p
       case _                                                  => "id"
+
+  // The docker-compose set and .env.example are identical across targets, so all
+  // three backends emit them from here instead of each re-listing the same files.
+  def composeAndEnvFiles(
+      composeIn: Compose.Inputs,
+      authEnv: List[EnvExample.Entry]
+  ): List[EmittedFile] =
+    List(
+      EmittedFile("docker-compose.yml", Compose.base(composeIn).yaml),
+      EmittedFile("docker-compose.override.yml.example", Compose.overrideExample(composeIn).yaml),
+      EmittedFile("docker-compose.staging.yml", Compose.staging(composeIn).yaml, preserve = true),
+      EmittedFile("docker-compose.prod.yml", Compose.prod(composeIn).yaml, preserve = true),
+      EmittedFile(".env.example", EnvExample.render(composeIn, authEnv))
+    )

--- a/modules/codegen/src/main/scala/specrest/codegen/EmitShared.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/EmitShared.scala
@@ -2,6 +2,7 @@ package specrest.codegen
 
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledEntity
+import specrest.profile.ProfiledField
 import specrest.profile.ProfiledService
 
 private[codegen] object EmitShared:
@@ -186,3 +187,78 @@ private[codegen] object EmitShared:
       EmittedFile("docker-compose.prod.yml", Compose.prod(composeIn).yaml, preserve = true),
       EmittedFile(".env.example", EnvExample.render(composeIn, authEnv))
     )
+
+  final case class KernelOutputShape(
+      entityOutput: Option[ProfiledEntity],
+      seqEntityOutput: Option[ProfiledEntity],
+      entityOutputFields: List[ProfiledField],
+      outFieldKinds: Map[String, KernelTypes.Kind]
+  )
+
+  // A kernel result's output shape: the single entity output (or the element type
+  // of a seq output), its read-shape fields with sensitive columns dropped, and the
+  // payload kind per field. Computed identically by all three targets.
+  def kernelOutputShape(
+      specOutputs: List[param_decl],
+      allEntities: List[ProfiledEntity],
+      ir: ServiceIRFull
+  ): KernelOutputShape =
+    val entityOutput = specOutputs match
+      case single :: Nil =>
+        prmType(single) match
+          case NamedTypeF(n, _) => allEntities.find(_.entityName == n)
+          case _                => None
+      case _ => None
+    val seqEntityOutput = specOutputs match
+      case single :: Nil =>
+        prmType(single) match
+          case SeqTypeF(NamedTypeF(n, _), _) => allEntities.find(_.entityName == n)
+          case _                             => None
+      case _ => None
+    val entityOutputFields = entityOutput
+      .orElse(seqEntityOutput)
+      .map(_.fields.filterNot(f => SensitiveFields.isSensitive(f.columnName)))
+      .getOrElse(Nil)
+    val outFieldKinds: Map[String, KernelTypes.Kind] = entityOutput
+      .orElse(seqEntityOutput)
+      .map(e =>
+        e.fields.flatMap { f =>
+          KernelTypes
+            .fieldKind(ir, e.entityName, f.fieldName)
+            .map {
+              case KernelTypes.Kind.OptOf(inner) => f.fieldName -> inner
+              case other                         => f.fieldName -> other
+            }
+        }.toMap
+      )
+      .getOrElse(Map.empty)
+    KernelOutputShape(entityOutput, seqEntityOutput, entityOutputFields, outFieldKinds)
+
+  // Whether a kernel output field can be marshaled into the response. Foreign keys are
+  // scalar aliases, so every marshalable field resolves to a kind; an unresolved field
+  // is not kernel-marshalable and the operation falls back to direct emit.
+  def outFieldOk(outFieldKinds: Map[String, KernelTypes.Kind], f: ProfiledField): Boolean =
+    outFieldKinds.get(f.fieldName) match
+      case Some(KernelTypes.Kind.Scalar(_))                            => true
+      case Some(KernelTypes.Kind.EnumK(_))                             => true
+      case Some(KernelTypes.Kind.SetOf(_) | KernelTypes.Kind.SeqOf(_)) => !f.nullable
+      case Some(KernelTypes.Kind.EntitySetOf(_))                       => !f.nullable
+      case _                                                           => false
+
+  // Whether an operation's outputs can be marshaled from the kernel result: no output
+  // is a plain effect call, an entity output needs every read-shape field marshalable,
+  // and a scalar output needs every field in the target's kernel-convertible set. That
+  // set is the only per-target input, since each language converts its own scalar types.
+  def kernelOutputsOk(
+      shape: KernelOutputShape,
+      specOutputs: List[param_decl],
+      scalarOutputs: List[ProfiledField],
+      scalarConvTypes: Set[String]
+  ): Boolean =
+    if specOutputs.isEmpty then true
+    else if shape.entityOutput.isDefined || shape.seqEntityOutput.isDefined then
+      shape.entityOutputFields.nonEmpty && shape.entityOutputFields.forall(outFieldOk(
+        shape.outFieldKinds,
+        _
+      ))
+    else scalarOutputs.nonEmpty && scalarOutputs.forall(f => scalarConvTypes.contains(f.domainType))

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -17,7 +17,6 @@ import specrest.codegen.RenderContext
 import specrest.codegen.ScalarOpView
 import specrest.codegen.ScalarOps
 import specrest.codegen.ScalarStateFieldView
-import specrest.codegen.SensitiveFields
 import specrest.codegen.TemplateEngine
 import specrest.codegen.migration.MigrationPlan
 import specrest.codegen.migration.SchemaCodec
@@ -1331,47 +1330,13 @@ func sampleCandidate(length int, charset string) (string, error) {
         // a single entity output projects the read shape nested under the
         // output name, a Seq of entities projects per element into the bare
         // array, and scalar outputs unpack positionally.
-        val entityOutput = specOutputs match
-          case single :: Nil =>
-            prmType(single) match
-              case NamedTypeF(n, _) => allEntities.find(_.entityName == n)
-              case _                => None
-          case _ => None
-        val seqEntityOutput = specOutputs match
-          case single :: Nil =>
-            prmType(single) match
-              case SeqTypeF(NamedTypeF(n, _), _) => allEntities.find(_.entityName == n)
-              case _                             => None
-          case _ => None
-        val entityOutputFields = entityOutput
-          .orElse(seqEntityOutput)
-          .map(_.fields.filterNot(f => SensitiveFields.isSensitive(f.columnName)))
-          .getOrElse(Nil)
-        val goEntityTypes = Set("string", "int64", "bool", "time.Time")
-        val outFieldKinds: Map[String, KernelTypes.Kind] = entityOutput
-          .orElse(seqEntityOutput)
-          .map(e =>
-            e.fields.flatMap { f =>
-              KernelTypes
-                .fieldKind(kernelCtx.ir, e.entityName, f.fieldName)
-                .map {
-                  case KernelTypes.Kind.OptOf(inner) => f.fieldName -> inner
-                  case other                         => f.fieldName -> other
-                }
-            }.toMap
-          )
-          .getOrElse(Map.empty)
-        def outFieldOk(f: ProfiledField): Boolean =
-          outFieldKinds.get(f.fieldName) match
-            case Some(KernelTypes.Kind.EnumK(_))                             => true
-            case Some(KernelTypes.Kind.SetOf(_) | KernelTypes.Kind.SeqOf(_)) => !f.nullable
-            case Some(KernelTypes.Kind.EntitySetOf(_))                       => !f.nullable
-            case _                                                           => goEntityTypes.contains(f.domainType.stripPrefix("*"))
+        val shape              = EmitShared.kernelOutputShape(specOutputs, allEntities, kernelCtx.ir)
+        val entityOutput       = shape.entityOutput
+        val seqEntityOutput    = shape.seqEntityOutput
+        val entityOutputFields = shape.entityOutputFields
+        val outFieldKinds      = shape.outFieldKinds
         val outputsOk =
-          if specOutputs.isEmpty then true
-          else if entityOutput.isDefined || seqEntityOutput.isDefined then
-            entityOutputFields.nonEmpty && entityOutputFields.forall(outFieldOk)
-          else outputs.nonEmpty && outputs.forall(f => goKernelScalarConv.contains(f.domainType))
+          EmitShared.kernelOutputsOk(shape, specOutputs, outputs, goKernelScalarConv.keySet)
         Option.when(convertedArgs.forall(_.isDefined) && outputsOk):
           val candidates = op.dafnyCandidates.map: c =>
             (toCamelCase(c.param), c.sampleLength, goCandidateCharsetConst(c.param))

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -259,19 +259,8 @@ object EmitGo:
       files += EmittedFile(path, engine.renderAny(tpl, projectScope))
 
     val composeIn = composeInputs(projectCtx.db)
-    files += EmittedFile("docker-compose.yml", Compose.base(composeIn).yaml)
-    files += EmittedFile(
-      "docker-compose.override.yml.example",
-      Compose.overrideExample(composeIn).yaml
-    )
-    files += EmittedFile(
-      "docker-compose.staging.yml",
-      Compose.staging(composeIn).yaml,
-      preserve = true
-    )
-    files += EmittedFile("docker-compose.prod.yml", Compose.prod(composeIn).yaml, preserve = true)
-    val authEnv = AuthSchemes.envEntries(profiled.ir).map((k, v) => EnvExample.Entry(k, v))
-    files += EmittedFile(".env.example", EnvExample.render(composeIn, authEnv))
+    val authEnv   = AuthSchemes.envEntries(profiled.ir).map((k, v) => EnvExample.Entry(k, v))
+    files ++= EmitShared.composeAndEnvFiles(composeIn, authEnv)
 
     files += EmittedFile(
       "internal/extensions/extensions.go",

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -810,45 +810,12 @@ object EmitPython:
     // entities projects per element into a bare JSON array (list routes
     // return the array itself); scalar outputs unpack positionally; no
     // outputs at all is a plain effect call.
-    val entityOutput = specOutputs match
-      case single :: Nil =>
-        prmType(single) match
-          case NamedTypeF(n, _) => allEntities.find(_.entityName == n)
-          case _                => None
-      case _ => None
-    val seqEntityOutput = specOutputs match
-      case single :: Nil =>
-        prmType(single) match
-          case SeqTypeF(NamedTypeF(n, _), _) => allEntities.find(_.entityName == n)
-          case _                             => None
-      case _ => None
-    // The API contract for an entity output is the entity's read shape: flat,
-    // with sensitive fields dropped exactly as the schema layer drops them.
-    val entityOutputFields = entityOutput.orElse(seqEntityOutput)
-      .map(_.fields.filterNot(f => SensitiveFields.isSensitive(f.columnName)))
-      .getOrElse(Nil)
-    // Optionality lives on the profiled nullable flag; the kinds map keeps
-    // the payload kind so projection and eligibility read one shape.
-    val entityFieldKinds: Map[String, KernelTypes.Kind] = entityOutput.orElse(seqEntityOutput)
-      .map(e =>
-        e.fields.flatMap { f =>
-          KernelTypes
-            .fieldKind(kernelCtx.ir, e.entityName, f.fieldName)
-            .map {
-              case KernelTypes.Kind.OptOf(inner) => f.fieldName -> inner
-              case other                         => f.fieldName -> other
-            }
-        }.toMap
-      )
-      .getOrElse(Map.empty)
-    def outFieldOk(f: ProfiledField): Boolean =
-      entityFieldKinds.get(f.fieldName) match
-        case Some(KernelTypes.Kind.Scalar(b))                            => (KernelScalarTypes + "datetime").contains(b)
-        case Some(KernelTypes.Kind.EnumK(_))                             => true
-        case Some(KernelTypes.Kind.SetOf(_) | KernelTypes.Kind.SeqOf(_)) => !f.nullable
-        case Some(KernelTypes.Kind.EntitySetOf(_))                       => !f.nullable
-        case Some(KernelTypes.Kind.OptOf(_))                             => false
-        case None                                                        => (KernelScalarTypes + "datetime").contains(baseDomain(f.domainType))
+    val shape                                 = EmitShared.kernelOutputShape(specOutputs, allEntities, kernelCtx.ir)
+    val entityOutput                          = shape.entityOutput
+    val seqEntityOutput                       = shape.seqEntityOutput
+    val entityOutputFields                    = shape.entityOutputFields
+    val entityFieldKinds                      = shape.outFieldKinds
+    def outFieldOk(f: ProfiledField): Boolean = EmitShared.outFieldOk(entityFieldKinds, f)
     val outsMarshalable =
       if specOutputs.isEmpty then true
       else if entityOutput.isDefined || seqEntityOutput.isDefined then

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -367,24 +367,13 @@ object EmitPython:
     files += EmittedFile("pyproject.toml", engine.renderAny(templates.pyproject, ctx))
     files += EmittedFile("Dockerfile", engine.renderAny(templates.dockerfile, ctx))
     val composeIn = composeInputs(ctx)
-    files += EmittedFile("docker-compose.yml", Compose.base(composeIn).yaml)
-    files += EmittedFile(
-      "docker-compose.override.yml.example",
-      Compose.overrideExample(composeIn).yaml
-    )
-    files += EmittedFile(
-      "docker-compose.staging.yml",
-      Compose.staging(composeIn).yaml,
-      preserve = true
-    )
-    files += EmittedFile("docker-compose.prod.yml", Compose.prod(composeIn).yaml, preserve = true)
     val authEnv = AuthSchemes.envEntries(profiled.ir).map: (k, v) =>
       EnvExample.Entry(
         k,
         v,
         Some("Credential for the spec's security scheme; unset rejects requests (401)")
       )
-    files += EmittedFile(".env.example", EnvExample.render(composeIn, authEnv))
+    files ++= EmitShared.composeAndEnvFiles(composeIn, authEnv)
     files += EmittedFile("Makefile", engine.renderAny(templates.makefile, ctx))
     files += EmittedFile(".gitignore", engine.renderAny(templates.gitignore, ctx))
     files += EmittedFile(".dockerignore", engine.renderAny(templates.dockerignore, ctx))

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -281,19 +281,8 @@ object EmitTs:
       files += EmittedFile(path, engine.renderAny(tpl, projectScope))
 
     val composeIn = composeInputs(projectCtx.db)
-    files += EmittedFile("docker-compose.yml", Compose.base(composeIn).yaml)
-    files += EmittedFile(
-      "docker-compose.override.yml.example",
-      Compose.overrideExample(composeIn).yaml
-    )
-    files += EmittedFile(
-      "docker-compose.staging.yml",
-      Compose.staging(composeIn).yaml,
-      preserve = true
-    )
-    files += EmittedFile("docker-compose.prod.yml", Compose.prod(composeIn).yaml, preserve = true)
-    val authEnv = AuthSchemes.envEntries(profiled.ir).map((k, v) => EnvExample.Entry(k, v))
-    files += EmittedFile(".env.example", EnvExample.render(composeIn, authEnv))
+    val authEnv   = AuthSchemes.envEntries(profiled.ir).map((k, v) => EnvExample.Entry(k, v))
+    files ++= EmitShared.composeAndEnvFiles(composeIn, authEnv)
 
     files += EmittedFile(
       "src/extensions/index.ts",

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -16,7 +16,6 @@ import specrest.codegen.RenderContext
 import specrest.codegen.ScalarOpView
 import specrest.codegen.ScalarOps
 import specrest.codegen.ScalarStateFieldView
-import specrest.codegen.SensitiveFields
 import specrest.codegen.TemplateEngine
 import specrest.codegen.TsTemplates
 import specrest.codegen.migration.MigrationPlan
@@ -1171,47 +1170,12 @@ object EmitTs:
       // Mirrors the python and go marshalling: no outputs is a plain effect
       // call, a single entity output projects the read shape flat, scalars
       // unpack positionally.
-      val entityOutput = specOutputs match
-        case single :: Nil =>
-          prmType(single) match
-            case NamedTypeF(n, _) => allEntities.find(_.entityName == n)
-            case _                => None
-        case _ => None
-      val seqEntityOutput = specOutputs match
-        case single :: Nil =>
-          prmType(single) match
-            case SeqTypeF(NamedTypeF(n, _), _) => allEntities.find(_.entityName == n)
-            case _                             => None
-        case _ => None
-      val entityOutputFields = entityOutput
-        .orElse(seqEntityOutput)
-        .map(_.fields.filterNot(f => SensitiveFields.isSensitive(f.columnName)))
-        .getOrElse(Nil)
-      val tsEntityTypes = Set("string", "number", "boolean", "Date")
-      val outFieldKinds: Map[String, KernelTypes.Kind] = entityOutput
-        .orElse(seqEntityOutput)
-        .map(e =>
-          e.fields.flatMap { f =>
-            KernelTypes
-              .fieldKind(kernelCtx.ir, e.entityName, f.fieldName)
-              .map {
-                case KernelTypes.Kind.OptOf(inner) => f.fieldName -> inner
-                case other                         => f.fieldName -> other
-              }
-          }.toMap
-        )
-        .getOrElse(Map.empty)
-      def outFieldOk(f: ProfiledField): Boolean =
-        outFieldKinds.get(f.fieldName) match
-          case Some(KernelTypes.Kind.EnumK(_))                             => true
-          case Some(KernelTypes.Kind.SetOf(_) | KernelTypes.Kind.SeqOf(_)) => !f.nullable
-          case Some(KernelTypes.Kind.EntitySetOf(_))                       => !f.nullable
-          case _                                                           => tsEntityTypes.contains(f.domainType.replaceAll("\\s*\\|\\s*null$", ""))
+      val shape              = EmitShared.kernelOutputShape(specOutputs, allEntities, kernelCtx.ir)
+      val entityOutput       = shape.entityOutput
+      val seqEntityOutput    = shape.seqEntityOutput
+      val entityOutputFields = shape.entityOutputFields
       val outputsOk =
-        if specOutputs.isEmpty then true
-        else if entityOutput.isDefined || seqEntityOutput.isDefined then
-          entityOutputFields.nonEmpty && entityOutputFields.forall(outFieldOk)
-        else outputs.nonEmpty && outputs.forall(f => tsKernelScalarConv.contains(f.domainType))
+        EmitShared.kernelOutputsOk(shape, specOutputs, outputs, tsKernelScalarConv.keySet)
       // A redirect op's route issues `res.redirect(status, result)`, so the kernel result must be a
       // single string (the redirect target); otherwise leave it to the redirect route-kind branch.
       val redirectOk =


### PR DESCRIPTION
Two related cross-backend dedups in the codegen emitters, both output-preserving.

**Compose and env scaffolding.** The Python, Go, and TypeScript emitters each re-listed the same five project files (the four `docker-compose` variants and `.env.example`), which are identical whatever the target language. Moved into `EmitShared.composeAndEnvFiles`; each backend keeps its own `Compose.Inputs` and, for Python, its commented `authEnv`.

**Kernel-output marshalling.** Each emitter recomputed the kernel output shape (the entity output, its read-shape fields with sensitive columns dropped, the per-field kind) and an eligibility check for whether the outputs can be marshaled from the kernel result. Go and TS carried a per-language scalar check (`goEntityTypes` / `tsEntityTypes` against the rendered type name); Python used a `Kind`-based check with a domain-type fallback.

That divergence was accidental. Foreign keys in the specs are scalar aliases (`OrderId`, `UserId`, `ShortCode`), so `KernelTypes.resolve` follows them to a primitive and every entity field resolves to a `Kind`. `Kind.Scalar` only ever holds one of the four primitives, so the scalar arm is always true and the per-language type-name sets never affect output. Folded the shape and the eligibility decision into `EmitShared.kernelOutputShape` and `kernelOutputsOk`, leaving one `outFieldOk` with no Go/TS difference. The only per-target input to `kernelOutputsOk` is each language's own scalar-conversion key set, which already exists for the conversion code itself.

Output is unchanged: 403 codegen tests pass (including `ComposeOverlayEmitTest`, `DialectProfileEmitTest`, and the three per-backend emit suites), and the conformance suites exercise the kernel path across every spec, database, and target. I verified against all four fixtures that no entity field resolves to `None`, so the removed fallback was dead for real specs. Net change is about 47 fewer lines, and the changed-code duplication gate is back to 0.65% (the residual is the two files' shared import block, which can't be deduped).

This came out of a branch-density review. The genuinely shared code was cross-backend scaffolding and marshalling structure, not the exhaustive `match` dispatch on the sealed IR, which is load-bearing and stays per backend.
