### PR TITLE
fix(verify): keep inner-bound variables out of quantifier E-matching triggers

### DIFF
--- a/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
@@ -2,18 +2,15 @@ package specrest.verify.z3
 
 object Z3Trigger:
 
-  // Minimal uninterpreted-function applications covering every bound name: an
-  // App is a trigger only if no proper sub-App already covers the bound set,
-  // so we pick `store_dom(k)` over `len(store_map(k))`. `innerBound` carries the
-  // names bound by quantifiers crossed on the way down; a legal E-matching
-  // pattern cannot mention one, so an App that touches them is skipped (we keep
-  // descending into its args for a cleaner covering sub-App).
   private def minimalCovering(
       names: Set[String],
       innerBound: Set[String],
       e: Z3Expr
   ): List[Z3Expr] =
     e match
+      // The minimal covering App, and never one that mentions a name bound by an
+      // inner quantifier (`innerBound`): a legal E-matching pattern cannot. The
+      // sub-App preference then picks `store_dom(k)` over `len(store_map(k))`.
       case app @ Z3Expr.App(_, args, _)
           if names.subsetOf(app.freeVars) && app.freeVars.intersect(innerBound).isEmpty =>
         val sub = args.flatMap(minimalCovering(names, innerBound, _))

--- a/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
@@ -2,19 +2,26 @@ package specrest.verify.z3
 
 object Z3Trigger:
 
-  private def freeVarNames(e: Z3Expr): Set[String] = e match
-    case Z3Expr.Var(n, _, _) => Set(n)
-    case other               => other.children.foldLeft(Set.empty[String])(_ ++ freeVarNames(_))
-
   // Minimal uninterpreted-function applications covering every bound name: an
   // App is a trigger only if no proper sub-App already covers the bound set,
-  // so we pick `store_dom(k)` over `len(store_map(k))`.
-  private def minimalCovering(names: Set[String], e: Z3Expr): List[Z3Expr] = e match
-    case app @ Z3Expr.App(_, args, _) if names.subsetOf(freeVarNames(app)) =>
-      val sub = args.flatMap(minimalCovering(names, _))
-      if sub.nonEmpty then sub else List(app)
-    case other =>
-      other.children.flatMap(minimalCovering(names, _))
+  // so we pick `store_dom(k)` over `len(store_map(k))`. `innerBound` carries the
+  // names bound by quantifiers crossed on the way down; a legal E-matching
+  // pattern cannot mention one, so an App that touches them is skipped (we keep
+  // descending into its args for a cleaner covering sub-App).
+  private def minimalCovering(
+      names: Set[String],
+      innerBound: Set[String],
+      e: Z3Expr
+  ): List[Z3Expr] =
+    e match
+      case app @ Z3Expr.App(_, args, _)
+          if names.subsetOf(app.freeVars) && app.freeVars.intersect(innerBound).isEmpty =>
+        val sub = args.flatMap(minimalCovering(names, innerBound, _))
+        if sub.nonEmpty then sub else List(app)
+      case Z3Expr.Quantifier(_, bs, body, _) =>
+        minimalCovering(names, innerBound ++ bs.map(_.name), body)
+      case other =>
+        other.children.flatMap(minimalCovering(names, innerBound, _))
 
   // E-matching patterns for a quantifier body. Universals over native theory
   // sorts (String) with no patterns drive Z3 to MBQI, which cannot enumerate
@@ -26,7 +33,7 @@ object Z3Trigger:
     if names.isEmpty then Nil
     else
       val fromGuard = body match
-        case Z3Expr.Implies(g, _, _) => minimalCovering(names, g)
+        case Z3Expr.Implies(g, _, _) => minimalCovering(names, Set.empty, g)
         case _                       => Nil
-      val cands = if fromGuard.nonEmpty then fromGuard else minimalCovering(names, body)
+      val cands = if fromGuard.nonEmpty then fromGuard else minimalCovering(names, Set.empty, body)
       cands.distinct

--- a/modules/verify/src/test/scala/specrest/verify/z3/TriggerInferenceTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TriggerInferenceTest.scala
@@ -1,0 +1,48 @@
+package specrest.verify.z3
+
+class TriggerInferenceTest extends munit.CatsEffectSuite:
+
+  private val S                    = Z3Sort.Uninterp("S")
+  private def v(n: String): Z3Expr = Z3Expr.Var(n, S)
+  private def bind(n: String)      = Z3Binding(n, S)
+
+  private val cases: List[(String, List[Z3Binding], Z3Expr, List[Z3Expr])] = List(
+    (
+      "flat body triggers on its minimal covering app",
+      List(bind("u")),
+      Z3Expr.Cmp(CmpOp.Ge, Z3Expr.App("age", List(v("u"))), Z3Expr.IntLit(BigInt(0))),
+      List(Z3Expr.App("age", List(v("u"))))
+    ),
+    (
+      "a guarded universal triggers on the guard, not the body",
+      List(bind("k")),
+      Z3Expr.Implies(Z3Expr.App("dom", List(v("k"))), Z3Expr.App("p", List(v("k")))),
+      List(Z3Expr.App("dom", List(v("k"))))
+    ),
+    (
+      "a covering app buried under an inner binder is still a valid trigger",
+      List(bind("i1")),
+      Z3Expr.Quantifier(
+        QKind.ForAll,
+        List(bind("i2")),
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("sku", List(v("i1"))), Z3Expr.App("sku", List(v("i2"))))
+      ),
+      List(Z3Expr.App("sku", List(v("i1"))))
+    ),
+    (
+      "an app that also mentions an inner-bound var is not a trigger",
+      List(bind("k")),
+      Z3Expr.Quantifier(QKind.Exists, List(bind("j")), Z3Expr.App("rel", List(v("k"), v("j")))),
+      Nil
+    ),
+    (
+      "a shadowing inner binder does not cover the outer name",
+      List(bind("k")),
+      Z3Expr.Quantifier(QKind.Exists, List(bind("k")), Z3Expr.App("g", List(v("k")))),
+      Nil
+    )
+  )
+
+  cases.foreach: (name, bindings, body, expected) =>
+    test(name):
+      assertEquals(Z3Trigger.infer(bindings, body), expected)


### PR DESCRIPTION
Trigger inference (`Z3Trigger`) walks a quantifier body to pick minimal uninterpreted-function applications as E-matching patterns. Its private `freeVarNames` helper collected every variable name in a subtree without subtracting names bound by inner quantifiers, and `minimalCovering` descended into inner quantifier bodies. Together those let it choose an application that mentions a variable bound by an inner quantifier and attach it as a `:pattern` on the outer quantifier, where that name is free. Such a pattern is invalid: Z3 drops it and the quantifier falls back to MBQI, the timeout the pattern machinery exists to avoid.

`forall k . exists j . rel(k, j)` reproduces it. The inferred pattern is `(rel k j)`, and `j` is bound by the inner `exists`.

The fix threads the set of inner-bound names down through `minimalCovering` and rejects any candidate that references one. It also switches the coverage test to the binder-aware `Z3Expr.freeVars` and deletes the divergent `freeVarNames`. When no valid trigger exists, the quantifier now gets none (MBQI) instead of an invalid one.

This was latent on every current spec. Bounded quantifiers (`all v in R | ...`) render as `forall v. (dom(v) => ...)`, and inference prefers the guard `dom(v)`, which never mentions an inner binder. Where inference does descend into an inner binder, for example `all i1 | all i2 | sku(i1) = sku(i2)` whose trigger `sku(i1)` sits inside the `i2` quantifier, the chosen application references only the outer variable and stays valid. A regression test pins that case so the fix does not over-correct and drop a legitimate deep trigger.

Evidence it changes no current output: I dumped the VCs for all eleven fixture specs that use quantifiers, before and after the change, and diffed the `.smt2` scripts. Every one is byte-identical, so there is no solve-time impact. Full `verify` suite passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Z3 trigger inference to avoid patterns that reference variables bound by inner quantifiers. This prevents Z3 from dropping invalid patterns and reduces MBQI fallbacks.

- **Bug Fixes**
  - Thread inner-bound names through `minimalCovering` and use binder-aware `Z3Expr.freeVars`; skip apps that touch them.
  - If no valid trigger exists, emit none instead of an invalid one.
  - Add tests for the inner-binder bug and a valid deep trigger; fixtures produce identical `.smt2`.
  - Docs: move the `minimalCovering` rationale next to its guard.

<sup>Written for commit 6b32be55dff23df4b93c83f60c63db73fd359bc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic Z3 trigger selection for quantified expressions, especially when nested binders or variable shadowing are involved.
  * Avoids selecting trigger expressions that depend on variables bound by inner quantifiers.

* **Tests**
  * Added coverage for implication guards, nested quantifiers, inner-bound variables, and shadowing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->